### PR TITLE
fix: use npx to resolve fern binary in publish workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -30,4 +30,4 @@ jobs:
       - name: Publish Docs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-        run: fern generate --docs --log-level debug
+        run: npx fern generate --docs --log-level debug


### PR DESCRIPTION
## Summary
- `fern generate` fails with `command not found` in CI because it's called directly, not via yarn/npx
- `fern check` works because it runs through `yarn fern-check` which resolves from `node_modules/.bin/`
- Fix: prefix with `npx` to resolve the locally installed binary

## Test plan
- [ ] Merge and verify the publish-docs workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)