### PR TITLE
corrected missed link

### DIFF
--- a/fern/products/swml/pages/reference/methods/ai/languages/index.mdx
+++ b/fern/products/swml/pages/reference/methods/ai/languages/index.mdx
@@ -30,7 +30,7 @@ Use `ai.languages` to configure the spoken language of your AI Agent, as well as
 <ParamField path="languages[].code" type="string" required={true}>
   Set the language code for ASR (Automatic Speech Recognition) (STT (Speech-to-text)) purposes.
   By default, SignalWire uses Deepgram's Nova-3 STT engine, so this value should match a code from Deepgram's [Nova-3 language codes table][deepgram-codes].
-<Info> If a different STT model was selected using the [`openai_asr_engine` parameter](/docs/swml/reference/ai/params), you must select a code supported by that engine.</Info>
+<Info> If a different STT model was selected using the [`openai_asr_engine` parameter](/docs/swml/reference/ai/params#speech-recognition), you must select a code supported by that engine.</Info>
 </ParamField>
 
 <ParamField path="languages[].voice" type="string" required={true}>

--- a/fern/products/swml/pages/reference/methods/connect/index.mdx
+++ b/fern/products/swml/pages/reference/methods/connect/index.mdx
@@ -608,7 +608,7 @@ When connecting to a WebSocket stream destination with a `status_url`, SignalWir
 
 Use a Call Fabric Resource with the `connect` method by simply including the Resource Address.
 
-Learn more about [Resources](/docs/platform/resources) and [Addresses](/docs/platform/resources).
+Learn more about [Resources](/docs/platform/resources) and [Addresses](/docs/platform/addresses).
 
 <CodeBlocks>
 <CodeBlock title="YAML">

--- a/fern/products/swml/pages/reference/methods/execute.mdx
+++ b/fern/products/swml/pages/reference/methods/execute.mdx
@@ -48,7 +48,7 @@ Will use the [`switch`](/docs/swml/reference/switch) method when the `return_val
 The destination string can be one of:
 
 - `"section_name"` - section in the current document to execute. (For example: `main`)
-- A URL (http or https) - URL pointing to the document to execute. An HTTP POST request will be sent to the URL. The `params` object is passed, along with the variables and the [`Call`](/docs/swml/reference/variables#variables-list) object. Authentication can also be set in the url in the format of `username:password@url`.
+- A URL (http or https) - URL pointing to the document to execute. An HTTP POST request will be sent to the URL. The `params` object is passed, along with the variables and the [`Call`](/docs/swml/reference/variables#reference) object. Authentication can also be set in the url in the format of `username:password@url`.
 - An inline SWML document (as a JSON string) - SWML document provided directly as a JSON string.
 
 </Indent>

--- a/fern/products/swml/pages/reference/methods/switch.mdx
+++ b/fern/products/swml/pages/reference/methods/switch.mdx
@@ -31,10 +31,9 @@ Execute different instructions based on a variable's value
 </ParamField>
 
 
-### case_params
-
-The `case_params` object serves as a dictionary where each key is a string identifier, and
-the associated value is an array of SWML Method objects.
+<ParamField path="case_params" type="object" required={true}>
+  Serves as a dictionary where each key is a string identifier, and the associated value is an array of SWML Method Objects
+</ParamField>
 
 <Indent>
 


### PR DESCRIPTION
one link missed that was corrected

## Description

corrected missed link so that it references the closest linkable H2 as the individual param is not linkable.

## Type of Change

- [x] Documentation update



## Checklist

- [x] I have updated documentation (if applicable)


