### PR TITLE
Link fixes for call flow builder docs

### DIFF
--- a/fern/products/call-flow-builder/pages/core/overview.mdx
+++ b/fern/products/call-flow-builder/pages/core/overview.mdx
@@ -6,6 +6,7 @@ description: Learn about the Call Flow Builder, a visual tool for creating and m
 sidebar-title: Overview
 position: 0
 slug: /
+max-toc-depth: 3
 ---
 
 ## Introduction
@@ -78,7 +79,7 @@ From here, click on the `Edit` option to open the Call Flow Builder page.
 
 
 #### Add a node
-When you first open a new Call Flow, you will see a canvas with a single [node](/docs/call-flow-builder/reference/nodes):
+When you first open a new Call Flow, you will see a canvas with a single node:
 the [Handle Call](/docs/call-flow-builder/reference/handle-call) node.
 This node is the entry point for incoming calls and serves as the start of all Call Flows.
 From here the Call Flow Builder interface allows you to create and manage call flow nodes using a visual drag-and-drop interface.

--- a/fern/products/call-flow-builder/pages/core/variables.mdx
+++ b/fern/products/call-flow-builder/pages/core/variables.mdx
@@ -2,6 +2,7 @@
 id: ca4c2ae8-2768-4941-b126-aae71c9e1e31
 title: Variables
 slug: /guides/variables
+max-toc-depth: 3
 ---
 
 ## Introduction
@@ -17,27 +18,27 @@ All variables must be in the following format to signal to the Call Flow Builder
 The following variables exist for all inbound calls. At this time, the direction is always inbound,
 but the other values are very useful and can be referenced throughout the whole Flow.
 
-<ParamField path="%{call.from}" type="string">
+<ParamField path="%{call.from}" type="string" toc={true}>
   The phone number of the caller.
 </ParamField>
 
-<ParamField path="%{call.to}" type="string">
+<ParamField path="%{call.to}" type="string" toc={true}>
   The phone number the call was made to.
 </ParamField>
 
-<ParamField path="%{call.direction}" type="string">
+<ParamField path="%{call.direction}" type="string" toc={true}>
   The direction of the call.
 </ParamField>
 
-<ParamField path="%{call.call_id}" type="string">
+<ParamField path="%{call.call_id}" type="string" toc={true}>
   The unique identifier for the call.
 </ParamField>
 
-<ParamField path="%{call.state}" type="string">
+<ParamField path="%{call.state}" type="string" toc={true}>
   The state of the call.
 </ParamField>
 
-<ParamField path="%{call.type}" type="string">
+<ParamField path="%{call.type}" type="string" toc={true}>
   The type of call.
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/core/version.mdx
+++ b/fern/products/call-flow-builder/pages/core/version.mdx
@@ -2,6 +2,7 @@
 id: 474b07f5-8186-4857-b14d-ea41f501be5e
 title: Versioning
 slug: /guides/version
+max-toc-depth: 3
 ---
 
 ## Introduction

--- a/fern/products/call-flow-builder/pages/nodes/ai_agent.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/ai_agent.mdx
@@ -4,6 +4,7 @@ title: AI Agent
 description: Call Flow Builder node to connect to an AI Agent
 slug: /reference/ai-agent
 # image: "/assets/images/call-flow/nodes/ai_agent_node.webp"
+max-toc-depth: 3
 ---
 This node is used to connect to a SignalWire conversational [AI agent](/docs/platform/ai/no-code-agents).
 The AI agent can be used to handle natural language processing, sentiment analysis, make and handle API calls, and other conversational tasks.
@@ -14,7 +15,7 @@ Learn more about AI Agents with our comprehensive [Getting Started](/docs/platfo
 
 ## **Node Settings**
 
-<ParamField path="AI Agent Name" type="string">
+<ParamField path="AI Agent Name" type="string" toc={true}>
   The name of the AI agent to connect to. The dropdown menu will populate with any [AI Agent Resource](/docs/platform/ai/no-code-agents) that have been created in your SignalWire portal.
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/answer_call.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/answer_call.mdx
@@ -4,6 +4,7 @@ title: Answer Call
 description: Call Flow Builder node to answer an incoming call.
 slug: /reference/answer-call
 # image: "/assets/images/call-flow/nodes/answer.webp"
+max-toc-depth: 3
 ---
 Answer Call marks the beginning of a call flow.
 

--- a/fern/products/call-flow-builder/pages/nodes/conditions.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/conditions.mdx
@@ -4,6 +4,7 @@ title: Conditions
 description: Call Flow Builder node to add conditions to your call flow.
 slug: /reference/conditions
 # image: "/assets/images/call-flow/nodes/block-condition.webp"
+max-toc-depth: 3
 ---
 A Conditions node works like a 
 [JavaScript if statement](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling#if...else_statement). 
@@ -17,17 +18,17 @@ The `Cond #` path will be executed for a truthy condition. The `Else` path will 
 
 ## Output Node Connectors
 
-<ParamField path="Condition" type="string">
+<ParamField path="Condition" type="string" toc={true}>
   The condition that is evaluated to determine which path to take. Additional conditions can be added by clicking the `Add condition` button. Additional conditions will act as JavaScript `else-if` statements.
 </ParamField>
 
-<ParamField path="Else" type="string">
+<ParamField path="Else" type="string" toc={true}>
   The path to take if none of the conditions are met.
 </ParamField>
 
 ## Node Settings
 
-<ParamField path="Conditions" type="string">
+<ParamField path="Conditions" type="string" toc={true}>
   The conditions that are evaluated to determine which path to take. Additional conditions can be added by clicking the `Add condition` button. Additional conditions will act as JavaScript `else-if` statements.
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/execute_swml.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/execute_swml.mdx
@@ -4,35 +4,36 @@ title: Execute SWML
 description: Call Flow Builder node to execute a remote SWML document and return to the current document.
 slug: /reference/execute-swml
 # image: "/assets/images/call-flow/nodes/swml_node.webp"
+max-toc-depth: 3
 ---
 Execute a remote [SWML](/docs/swml) document and return to the current document.
 Use `%{return_value.['object_field']}` to reference the return values from the external SWML.
 
 ## **Output Node Connectors**
 
-<ParamField path="Condition" type="string">
+<ParamField path="Condition" type="string" toc={true}>
   The condition that is evaluated to determine which path to take. Additional conditions can be added by clicking the `Add condition` button. Additional conditions will act as JavaScript `else-if` statements.
 </ParamField>
 
-<ParamField path="Else" type="string">
+<ParamField path="Else" type="string" toc={true}>
   The path to take if none of the conditions are met.
 </ParamField>
 
 ## **Node Settings**
 
-<ParamField path="URL" type="string">
+<ParamField path="URL" type="string" toc={true}>
   The URL of the SWML document to execute. The URL **must** return swml in valid `JSON` or `YAML` format.
 </ParamField>
 
-<ParamField path="Params" type="object">
+<ParamField path="Params" type="object" toc={true}>
   The parameters to pass to the SWML document.
 </ParamField>
 
-<ParamField path="Meta" type="object">
+<ParamField path="Meta" type="object" toc={true}>
   The metadata to pass to the SWML document. A JSON object to serialize.
 </ParamField>
 
-<ParamField path="Conditions" type="string">
+<ParamField path="Conditions" type="string" toc={true}>
   The conditions that are evaluated to determine which path to take. Additional conditions can be added by clicking the `Add condition` button. Additional conditions will act as JavaScript `else-if` statements.
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/forward_to_phone.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/forward_to_phone.mdx
@@ -3,6 +3,7 @@ id: f2728d31-d160-4ab1-bac5-29b45028d683
 title: Forward to Phone
 description: Call Flow Builder node to forward the call to a phone number.
 slug: /reference/forward-to-phone
+max-toc-depth: 3
 ---
 
 [variables]: /docs/call-flow-builder/guides/variables
@@ -12,23 +13,23 @@ This node will allow you to forward the incoming call to another phone or SIP en
 
 ## **Output Node Connectors**
 
-<ParamField path="Success" type="string">
+<ParamField path="Success" type="string" toc={true}>
   Call is forwarded successfully. The connector will be triggered when the call is successfully forwarded to the phone number.
 </ParamField>
 
-<ParamField path="No Answer" type="string">
+<ParamField path="No Answer" type="string" toc={true}>
   Call is not answered. The connector will be triggered when the call is not answered by the phone number.
 </ParamField>
 
-<ParamField path="Busy" type="string">
+<ParamField path="Busy" type="string" toc={true}>
   Call is busy. The connector will be triggered when the call is busy.
 </ParamField>
 
-<ParamField path="Decline" type="string">
+<ParamField path="Decline" type="string" toc={true}>
   Call is declined. The connector will be triggered when the call is declined.
 </ParamField>
 
-<ParamField path="Error" type="string">
+<ParamField path="Error" type="string" toc={true}>
   An error occurred. The connector will be triggered when an error occurs while forwarding the call.
 </ParamField>
 
@@ -36,23 +37,23 @@ This node will allow you to forward the incoming call to another phone or SIP en
 
 ## **Node Settings**
 
-<ParamField path="Default From" type="string">
+<ParamField path="Default From" type="string" toc={true}>
   The default phone number to use as the caller ID when forwarding the call.
 </ParamField>
 
-<ParamField path="Default Timeout" type="integer">
+<ParamField path="Default Timeout" type="integer" toc={true}>
   The time in seconds to wait for the call to be answered before timing-out and either disconnecting the call or attempting a new number.<br /><br />**Default Value:** 45 seconds.
 </ParamField>
 
-<ParamField path="Call State URL" type="string">
+<ParamField path="Call State URL" type="string" toc={true}>
   A webhook URL that will receive a POST request containing call details each time a Call State Event is triggered. You will need to choose which events you want listen for in the next field. If no events are chosen, the URL will receive no requests.
 </ParamField>
 
-<ParamField path="Call State Events" type="string">
+<ParamField path="Call State Events" type="string" toc={true}>
   The events that will trigger a POST request to the Call State URL.<br /><br />**Possible Values:** `created`, `ringing`, `answered`, `ended`
 </ParamField>
 
-<ParamField path="Call Numbers" type="string">
+<ParamField path="Call Numbers" type="string" toc={true}>
   _Only shows when multiple numbers are added_.<br /><br /> A toggle option to change the behavior of the forwarding of the call. If set to `Sequential`, the call will be forwarded to the next number in the list if the previous number is busy, declined, or not answered. If set to `Simultaneously`, the call will be forwarded to all numbers in the list at the same time.<br /><br />**Possible Values:** `Sequential`, `Simultaneously`
 </ParamField>
 
@@ -64,19 +65,19 @@ Additional phone numbers can be added by clicking the `Add Phone Number` button.
 Depending on the `Call Numbers` property, the call will be forwarded to the next number in the list (`Sequential`) 
 or to all numbers in the list at the same time (`Simultaneously`).
 
-<ParamField path="To" type="string">
+<ParamField path="To" type="string" toc={true}>
   The phone number or SIP endpoint to forward the call to.
 </ParamField>
 
-<ParamField path="From" type="string">
+<ParamField path="From" type="string" toc={true}>
   The phone number to use as the caller ID when forwarding the call. If not set, `Default From` will be used.
 </ParamField>
 
-<ParamField path="Timeout" type="integer">
+<ParamField path="Timeout" type="integer" toc={true}>
   The time in seconds to wait for the call to be answered before timing out and either disconnecting the call or attempting a new number. If not set, `Default Timeout` will be used.
 </ParamField>
 
-<ParamField path="Enable Whisper" type="boolean">
+<ParamField path="Enable Whisper" type="boolean" toc={true}>
   This executes [SWML](/docs/swml) when the call is answered. The SWML will be executed before connecting the call.<br /><br />**Handle Via:** `External URL` that is hosted off the SignalWire platform, or a [`SWML`](/docs/swml) script [resource](/docs/platform/resources).
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/gather_input.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/gather_input.mdx
@@ -3,6 +3,7 @@ id: 8afaf859-a3b9-4551-a62b-dca41ac17dbc
 title: Gather Input
 description: Call Flow Builder node to gather input from the caller.
 slug: /reference/gather-input
+max-toc-depth: 3
 ---
 This node is used to gather input from the caller using DTMF or speech recognition.
 During the gather period, the call can use an audio file or text-to-speech to prompt the caller to enter the input.
@@ -14,75 +15,75 @@ For every input option you can configure, an output node connection will be crea
 
 ## **Output Node Connectors**
 
-<ParamField path="Input Option" type="string">
+<ParamField path="Input Option" type="string" toc={true}>
   The output node connector for the first input option configured. This connector will be used when the input received matches the input option. Additional output node connectors will be created for each input option configured.
 </ParamField>
 
-<ParamField path="Unknown" type="string">
+<ParamField path="Unknown" type="string" toc={true}>
   The output node connector for when the `input received does not match` any of the input options configured.
 </ParamField>
 
-<ParamField path="No Input" type="string">
+<ParamField path="No Input" type="string" toc={true}>
   The output node connector for when `no input` is received from the caller.
 </ParamField>
 
 ## **Node Settings**
 
-<ParamField path="Text to Speech" type="object">
+<ParamField path="Text to Speech" type="object" toc={true}>
   Configure the text-to-speech settings for the gather input node. See [Text to Speech Settings](#text-to-speech-settings).
 </ParamField>
 
-<ParamField path="Audio File" type="object">
+<ParamField path="Audio File" type="object" toc={true}>
   Configure the audio file settings for the gather input node. See [Audio File Settings](#audio-file-settings).
 </ParamField>
 
 ### Text to Speech Settings
 
-<ParamField path="Language" type="string">
+<ParamField path="Language" type="string" toc={true}>
   The language to use for the text-to-speech.
 </ParamField>
 
-<ParamField path="Gender" type="string">
+<ParamField path="Gender" type="string" toc={true}>
   The gender of the voice to use for the text-to-speech.
 </ParamField>
 
-<ParamField path="Voice" type="string">
+<ParamField path="Voice" type="string" toc={true}>
   The voice to use for the text-to-speech.
 </ParamField>
 
-<ParamField path="Text" type="string">
+<ParamField path="Text" type="string" toc={true}>
   The text to convert to speech.
 </ParamField>
 
-<ParamField path="Wait for Input" type="integer">
+<ParamField path="Wait for Input" type="integer" toc={true}>
   The amount of time to wait for the caller to enter input.<br /><br />**Possible Values:** A number between `1-99` is required.
 </ParamField>
 
-<ParamField path="Wait for Digits" type="integer">
+<ParamField path="Wait for Digits" type="integer" toc={true}>
   The amount of time to wait for the caller to enter input.<br /><br />**Possible Values:** A number between `1-99` is required.
 </ParamField>
 
-<ParamField path="Input Options" type="array">
-  The input options to gather from the caller. Additional options can be added through the `Add option` button inside the node. See [Input Options](#input-options).
+<ParamField path="Input Options" type="array" toc={true}>
+  The input options to gather from the caller. Additional options can be added through the `Add option` button inside the node. See [Input Options](#input-options-2).
 </ParamField>
 
 ### Audio File Settings
 
-<ParamField path="Audio File" type="string">
+<ParamField path="Audio File" type="string" toc={true}>
   The URL of a audio file to play to the caller.
 </ParamField>
 
-<ParamField path="Input Options" type="array">
-  The input options to gather from the caller. Additional options can be added through the `Add option` button inside the node. See [Input Options](#input-options).
+<ParamField path="Input Options" type="array" toc={true}>
+  The input options to gather from the caller. Additional options can be added through the `Add option` button inside the node. See [Input Options](#input-options-2).
 </ParamField>
 
 ### Input Options
 
-<ParamField path="Caller presses" type="string">
+<ParamField path="Caller presses" type="string" toc={true}>
   The DTMF key that the caller must press to select this input option.<br /><br />**Possible Values:** A value of `0-9`, `*`, or `#` is required.
 </ParamField>
 
-<ParamField path="Or says" type="string">
+<ParamField path="Or says" type="string" toc={true}>
   The speech recognition value that the caller must say to select this input option.
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/handle_call.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/handle_call.mdx
@@ -3,6 +3,7 @@ id: eefe8a91-9eb9-4711-92a6-938d5a668f91
 title: Handle Call
 description: Call Flow Builder node to handle an incoming call.
 slug: /reference/handle-call
+max-toc-depth: 3
 ---
 The `Handle Call` node is used to handle an incoming call.
 It is the first node in the call flow, does not have an input connector and is mandatory in every call flow.

--- a/fern/products/call-flow-builder/pages/nodes/hangup_call.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/hangup_call.mdx
@@ -3,6 +3,7 @@ id: d05e53cf-c7f7-4b62-9cc1-48712174a816
 title: Hang Up Call
 description: Call Flow Builder node to hang up a call.
 slug: /reference/hangup-call
+max-toc-depth: 3
 ---
 The Hang Up Call node will disconnect a call and end the flow.
 
@@ -21,6 +22,6 @@ The **Reason** parameter is used for logging purposes and does not change the be
 
 ## Node Settings
 
-<ParamField path="Reason" type="string">
+<ParamField path="Reason" type="string" toc={true}>
   The reason for hanging up the call. <br /> **Possible Values:** `Busy`, `Decline`, `Hang up` <br /> **Default Value:** `Busy`
 </ParamField>

--- a/fern/products/call-flow-builder/pages/nodes/overview.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/overview.mdx
@@ -4,6 +4,7 @@ title: Overview
 sidebar-title: Overview
 slug: /reference/nodes
 position: 0
+max-toc-depth: 3
 ---
 
 ## Introduction

--- a/fern/products/call-flow-builder/pages/nodes/play_audio_or_tts.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/play_audio_or_tts.mdx
@@ -3,6 +3,7 @@ id: ac6af178-0fd6-4e1a-962c-07f27295d435
 title: Play Audio or TTS
 description: Call Flow Builder node to play audio or TTS to the caller.
 slug: /reference/play-audio-or-tts
+max-toc-depth: 3
 ---
 This node allows you to play an audio file, play silence, play a ringtone, or play text-to-speech.
 
@@ -10,11 +11,11 @@ This node allows you to play an audio file, play silence, play a ringtone, or pl
 
 ## **Node Settings**
 
-<ParamField path="Text to Speech" type="object">
+<ParamField path="Text to Speech" type="object" toc={true}>
   Text to Speech node options. See [Text to Speech Settings](#text-to-speech-settings).
 </ParamField>
 
-<ParamField path="Play Audio File" type="object">
+<ParamField path="Play Audio File" type="object" toc={true}>
   Play Audio file node options. See [Play Audio File Settings](#play-audio-file-settings).
 </ParamField>
 
@@ -22,19 +23,19 @@ This node allows you to play an audio file, play silence, play a ringtone, or pl
 
 Node options for Text to Speech.
 
-<ParamField path="Language" type="string">
+<ParamField path="Language" type="string" toc={true}>
   The language to use for the text-to-speech.
 </ParamField>
 
-<ParamField path="Gender" type="string">
+<ParamField path="Gender" type="string" toc={true}>
   The gender of the voice to use for the text-to-speech.
 </ParamField>
 
-<ParamField path="Voice" type="string">
+<ParamField path="Voice" type="string" toc={true}>
   The voice to use for the text-to-speech. <br /><br />Please note that any voices that show (premium) next to the name will be billed at the [Premium TTS rate](https://signalwire.com/pricing/voice).
 </ParamField>
 
-<ParamField path="Text" type="string">
+<ParamField path="Text" type="string" toc={true}>
   The text to convert to speech. [SSML](https://cloud.google.com/text-to-speech/docs/ssml) can be used to customize the speech. The text can also include [variables](/docs/call-flow-builder/reference/set-variables) to be replaced with the variable value.<br /><br />**SSML Example:** `<speak>Here is a <say-as interpret-as="characters">SSML</say-as> example</speak>`<br /><br />**Variables Example:** `Hello, you got a call from %{call.from}`
 </ParamField>
 
@@ -42,7 +43,7 @@ Node options for Text to Speech.
 
 Node options for Play Audio File.
 
-<ParamField path="Audio File" type="string">
+<ParamField path="Audio File" type="string" toc={true}>
   A URL of a audio file to play.<br />Additionally a [ringtone](/docs/server-sdk/node/reference/voice/types#ringtonename) or silence can be played over the call.<br /><br />**Ringtone Format:** `silence:<time in seconds>` (ex: `silence:5`)<br />**Silence Format:** `ring:<time in seconds><ringtone code>` (ex: `ring:5:jp`)
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/request.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/request.mdx
@@ -3,6 +3,7 @@ id: 6fd48151-b077-4f9d-9320-94d11fe1289f
 title: Request
 description: Call Flow Builder node to make an HTTP request
 slug: /reference/request
+max-toc-depth: 3
 ---
 This node will allow you to make a `GET`, `POST`, `PUT`, or `DELETE` request to the specified URL.
 The response can be accessed in later nodes with `%{request_response_body}`, and if you choose to save the response fields
@@ -11,40 +12,37 @@ as variables, you can reference them with `%{request_response.<object_field>}`.
 It is important to note that later Request nodes will overwrite the `%{request_response}` variables,
 so either use them immediately or store them with a [Set Variables](/docs/call-flow-builder/reference/set-variables) node.
 
-For a more in-depth explanation of using variables, see the
-[Using Variables](/docs/call-flow-builder/reference/set-variables)
-section of our introduction to Call Flow Builder.
 
 
 ## **Output Node Connectors**
 
-<ParamField path="Condition" type="string">
+<ParamField path="Condition" type="string" toc={true}>
   User-defined success condition. The condition can be based on the requests response body in the following format: `%{request_response.<object_field>}`. Additional conditions can be added by clicking the `Add condition` button, which will create a new connector.
 </ParamField>
 
-<ParamField path="Else" type="string">
+<ParamField path="Else" type="string" toc={true}>
   The default output connector when the condition is not met.
 </ParamField>
 
-<ParamField path="Failure" type="string">
+<ParamField path="Failure" type="string" toc={true}>
   The output connector when the request fails.
 </ParamField>
 
 ## Node Settings
 
-<ParamField path="URL" type="string">
+<ParamField path="URL" type="string" toc={true}>
   A public URL to make the request to.
 </ParamField>
 
-<ParamField path="Method" type="string">
+<ParamField path="Method" type="string" toc={true}>
   The HTTP method to use for the request.<br /><br />**Possible Values:** `GET`, `POST`, `PUT`, `DELETE`
 </ParamField>
 
-<ParamField path="Headers" type="object">
+<ParamField path="Headers" type="object" toc={true}>
   A list of headers to include in the request. Each header should be in JSON format ` { key: value }`<br /><br />**Example:** `{ "Content-Type": "application/json", "X-Custom-Header": "foo" }`
 </ParamField>
 
-<ParamField path="Body" type="object">
+<ParamField path="Body" type="object" toc={true}>
   The body of the request. This field can be used to send any string or JSON data that can be serialized.<br /><br />**Example:** `{"user": { "id": 123, "role": "admin", "isActive": true }}`
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/send_sms.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/send_sms.mdx
@@ -3,21 +3,22 @@ id: d67de0e5-2ee8-4841-ac69-6a4462a87ee1
 title: Send SMS
 description: Call Flow Builder node to send an SMS
 slug: /reference/send-sms
+max-toc-depth: 3
 ---
 The Send SMS node is used to send an SMS to a phone number.
 
 
 ## **Node Settings**
 
-<ParamField path="To Phone Number" type="string">
+<ParamField path="To Phone Number" type="string" toc={true}>
   The phone number to which the SMS will be sent.
 </ParamField>
 
-<ParamField path="From Phone Number" type="string">
+<ParamField path="From Phone Number" type="string" toc={true}>
   The phone number from which the SMS will be sent.
 </ParamField>
 
-<ParamField path="SMS Text" type="string">
+<ParamField path="SMS Text" type="string" toc={true}>
   The text of the SMS that will be sent.
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/set_variables.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/set_variables.mdx
@@ -4,6 +4,7 @@ title: Set Variables
 description: Call Flow Builder node to set variables in the call flow.
 slug: /reference/set-variables
 # image: "/assets/images/call-flow/nodes/set-variables.webP"
+max-toc-depth: 3
 ---
 Use this node to set variables that can be accessed from other nodes in the Call Flow.
 
@@ -13,18 +14,15 @@ or a call parameter ( `%{call.from} `).
 
 Access these variables in other blocks with `%{<Key>}` and unset variables with the [Unset Variables](/docs/call-flow-builder/reference/unset-variables) node.
 
-For a more in-depth explanation of using variables, see the
-[Using Variables](/docs/call-flow-builder/reference/set-variables)
-section of our introduction to Call Flow Builder.
 
 
 ## **Node Settings**
 
-<ParamField path="Key" type="string">
+<ParamField path="Key" type="string" toc={true}>
   The name of the variable to set.
 </ParamField>
 
-<ParamField path="Value" type="string">
+<ParamField path="Value" type="string" toc={true}>
   The value to set the variable to. This can be a static value, a variable from another node, or a call parameter.
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/start_call_recording.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/start_call_recording.mdx
@@ -4,6 +4,7 @@ title: Start Call Recording
 description: Call Flow Builder node to start recording a call.
 slug: /reference/start-call-recording
 # image: "/assets/images/call-flow/nodes/start_recording.webp"
+max-toc-depth: 3
 ---
 This node triggers background recording of both sides of the call. 
 The recording will automatically stop if the call is disconnected.
@@ -12,23 +13,23 @@ To manually stop the recording, use the [Stop Call Recording](/docs/call-flow-bu
 
 ## Node Settings
 
-<ParamField path="Recording Name" type="string">
+<ParamField path="Recording Name" type="string" toc={true}>
   The name of the recording file. The name is user-defined.<br /><br />**Default Value:** `Recording 1`
 </ParamField>
 
-<ParamField path="Stereo" type="boolean">
+<ParamField path="Stereo" type="boolean" toc={true}>
   If enabled, the recording will be in stereo. If disabled, the recording will be in mono.<br /><br />**Default Value:** `toggled off`
 </ParamField>
 
-<ParamField path="Beep" type="boolean">
+<ParamField path="Beep" type="boolean" toc={true}>
   If enabled, a beep sound will be played at the beginning of the recording.<br /><br />**Default Value:** `toggled off`
 </ParamField>
 
-<ParamField path="Terminators" type="string">
+<ParamField path="Terminators" type="string" toc={true}>
   The DTMF digits that will stop the recording. The recording will stop when any of the specified digits are pressed.<br /><br />**Default Value:** `None`
 </ParamField>
 
-<ParamField path="Format" type="string">
+<ParamField path="Format" type="string" toc={true}>
   The format of the recording file. The available formats are `wav` and `mp3`.<br /><br />**Default Value:** `wav`
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/stop_call_recording.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/stop_call_recording.mdx
@@ -4,6 +4,7 @@ title: Stop Call Recording
 description: Call Flow Builder node to stop recording a call.
 slug: /reference/stop-call-recording
 # image: "/assets/images/call-flow/nodes/record-call.webP"
+max-toc-depth: 3
 ---
 Stops the specified recording action. 
 Reference the recording URL in other nodes in the Flow using the variable `%{record_call_url}`.
@@ -12,7 +13,7 @@ You can also access the recording URL from the call log details in your [RELAY S
 
 ## **Node Settings**
 
-<ParamField path="Recording Name" type="string">
+<ParamField path="Recording Name" type="string" toc={true}>
   The name of the recording to stop. This should be connected to a [Start Call Recording](/docs/call-flow-builder/reference/start-call-recording) node and match the recording name.
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/unset_variables.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/unset_variables.mdx
@@ -4,6 +4,7 @@ title: Unset Variables
 description: Call Flow Builder node to unset variables in the call flow.
 slug: /reference/unset-variables
 # image: "/assets/images/call-flow/nodes/unset_vars.webp"
+max-toc-depth: 3
 ---
 The Unset Variables is used to clear any variable that was set using [Set Variables](/docs/call-flow-builder/reference/set-variables).
 All currently set variables are populated in the dropdown menu.
@@ -11,7 +12,7 @@ You can unset multiple variables in one node by selecting multiple variables fro
 
 ## Node Settings
 
-<ParamField path="Variables" type="array">
+<ParamField path="Variables" type="array" toc={true}>
   The variables that you want to unset. Variables will show in the drop-down menu if they are set in the call flow. Variables are set by [Set Variables](/docs/call-flow-builder/reference/set-variables) node.
 </ParamField>
 

--- a/fern/products/call-flow-builder/pages/nodes/voicemail_recording.mdx
+++ b/fern/products/call-flow-builder/pages/nodes/voicemail_recording.mdx
@@ -4,6 +4,7 @@ title: Voicemail Recording
 description: Call Flow Builder node to record voicemail messages.
 slug: /reference/voicemail-recording
 # image: "/assets/images/call-flow/nodes/simple-voicemail.webP"
+max-toc-depth: 3
 ---
 This node uses the asynchronous recording method to record a voicemail.
 Reference the recording URL in other nodes in the Flow using the variable `%{record_url}`.
@@ -12,31 +13,31 @@ You can also access the recording URL from the call log details in your [RELAY S
 
 ## **Node Settings**
 
-<ParamField path="Stereo" type="boolean">
+<ParamField path="Stereo" type="boolean" toc={true}>
   Record in stereo. Toggle this on to separate the two legs of the call recording into left and right channels.<br /><br />**Default Value:** `Toggled Off`
 </ParamField>
 
-<ParamField path="Beep" type="boolean">
+<ParamField path="Beep" type="boolean" toc={true}>
   Play a beep before recording starts. <br /><br />**Default Value:** `Toggled Off`
 </ParamField>
 
-<ParamField path="Terminators" type="string">
+<ParamField path="Terminators" type="string" toc={true}>
   DTMF digits that will stop the recording. Multiple DTMF tones can be added by being seperated by a comma.<br /><br />**Default Value:** `None`<br /><br />**Possible Values:** Digits `0-9`, `*`, `#`
 </ParamField>
 
-<ParamField path="Maximum Recording Length" type="integer">
+<ParamField path="Maximum Recording Length" type="integer" toc={true}>
   The maximum length of the recording in seconds.<br /><br /> **Possible Values:** `1-3600` seconds
 </ParamField>
 
-<ParamField path="Initial Timeout" type="integer">
+<ParamField path="Initial Timeout" type="integer" toc={true}>
   The time in seconds to wait for the first DTMF digit before starting the recording.<br /><br />**Possible Values:** `1-99` seconds
 </ParamField>
 
-<ParamField path="End Silence Timeout" type="integer">
+<ParamField path="End Silence Timeout" type="integer" toc={true}>
   The time in seconds to wait for the end of the call before ending the recording.<br /><br />**Possible Values:** `1-99` seconds
 </ParamField>
 
-<ParamField path="Format" type="string">
+<ParamField path="Format" type="string" toc={true}>
   The format of the recording.<br /><br />**Possible Values:** `wav`, `mp3`
 </ParamField>
 


### PR DESCRIPTION
## Description

Link fixes for call flow builder docs. Also added max-toc-depth: 3 to front matter of all pages and toc=true to all paramfields to resolve any issues in linking to specific fields.

## Type of Change


- [x] Documentation update



## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have updated documentation (if applicable)

