### PR TITLE
Fix webhook timeout defaults and parameter names

### DIFF
--- a/fern/products/compatibility-api/pages/cxml/guides/webhooks/common-webhook-errors.mdx
+++ b/fern/products/compatibility-api/pages/cxml/guides/webhooks/common-webhook-errors.mdx
@@ -7,7 +7,7 @@ Below are some examples of common errors that you might encounter when using web
 
 ## HTML retrieval error (error code 11200)
 
-HTML Retrieval Errors happen when there is a failure to retrieve the contents of the URL in your webhook. This indicates that SignalWire tried to reach your URL but did not receive a response before the connection timed out. Our current timeouts are 4.5 seconds for Connect and 5 seconds for Read, and we retry twice once the connection times out.
+HTML Retrieval Errors happen when there is a failure to retrieve the contents of the URL in your webhook. This indicates that SignalWire tried to reach your URL but did not receive a response before the connection timed out. Our current timeouts are 2 seconds for Connect and 5 seconds for Read, and we retry twice once the connection times out.
 
 SignalWire automatically retries HTTP retrieval requests. If it's an action type of webhook, SignalWire won't attempt a retry but will go to the fallback URL (on inbound calls, can specify an action URL and a fallback URL). If it's a status callback webhook, SignalWire will retry three times, and back off slightly between each attempt. So the second one will retry very quickly, and for the third retry, the system will wait a few seconds.
 

--- a/fern/products/compatibility-api/pages/cxml/guides/webhooks/index.mdx
+++ b/fern/products/compatibility-api/pages/cxml/guides/webhooks/index.mdx
@@ -146,18 +146,18 @@ https://your-server.com/endpoint#key=value&key2=value2
 
 | Parameter | Valid values | Default | Notes |
 |-----------|--------------|---------|-------|
-| Connect Timeout (`ct`) | 100 - 10000 (ms) | 5000 | The timeout in milliseconds SignalWire will wait to establish its TCP connection to your web server. |
-| Read Timeout (`rt`) | 100 - 15000 (ms) | 15000 | The amount of time in milliseconds after sending your webhook an HTTP request that SignalWire will wait for the initial HTTP response packet. Also applies to the amount of time SignalWire will wait between individual packets within your HTTP response. |
+| Open Timeout (`ot`) | 100 - 10000 (ms) | 2000 | The timeout in milliseconds SignalWire will wait to establish its TCP connection to your web server. |
+| Read Timeout (`rt`) | 100 - 15000 (ms) | 5000 | The amount of time in milliseconds after sending your webhook an HTTP request that SignalWire will wait for the initial HTTP response packet. Also applies to the amount of time SignalWire will wait between individual packets within your HTTP response. |
 | Total Time (`tt`) | 100 - 15000 (ms) | 15000 | The total time allowed for all timeouts including retries. If not set, the maximum limit is enforced. |
 
 ### Examples
 
-#### Set Connect Timeout to 1 second
+#### Set Open Timeout to 1 second
 ```
-https://example.com/foo#ct=1000
+https://example.com/foo#ot=1000
 ```
 
-#### Set Connect + Read Timeout to 1 second each
+#### Set Open + Read Timeout to 1 second each
 ```
-https://example.com/foo#ct=1000&rt=1000
+https://example.com/foo#ot=1000&rt=1000
 ```


### PR DESCRIPTION
## Summary

Fixes webhook documentation to reflect actual system timeout values, per [cloud-product#18500](https://github.com/signalwire/cloud-product/issues/18500).

- **Connect timeout parameter**: Renamed `ct` to `ot` (open timeout) — `laml-fetcher` implements `ot`, not `ct`
- **Connect timeout default**: Changed from 5000ms to **2000ms** (matches `Signalwire::CONNECTION_TIMEOUT` in prime-rails)
- **Read timeout default**: Changed from 15000ms to **5000ms** (matches `Signalwire::REQUEST_TIMEOUT` in prime-rails)
- **Common webhook errors page**: Updated connect timeout from "4.5 seconds" to "2 seconds"

## Oddities found during investigation

1. **`laml-fetcher` and `prime-rails` have different connect timeout defaults.** `laml-fetcher` uses 4500ms (open_timeout), `prime-rails` uses 2000ms (CONNECTION_TIMEOUT). LaML instruction webhooks and status callbacks will behave differently.

2. **Webhook connection overrides (`ot`, `rt`, `tt`) only work on LaML instruction webhooks** (routed through `laml-fetcher`). Status callbacks (`prime-rails` `SendCallback`) ignore URL fragment parameters entirely — they always use hardcoded constants. This was reported in [cloud-product#17729](https://github.com/signalwire/cloud-product/issues/17729) and acknowledged as a known gap.

3. **`tt` (Total Time) is not implemented anywhere.** Neither `laml-fetcher` nor `prime-rails` parse or enforce a total time parameter. Left in the docs for now — product should decide whether to implement or remove it.

4. **The `laml-fetcher` test suite has a misleading comment** — labels the `ot` parameter test as "connection timeout (ct) fragment" (`laml-fetcher/spec/lib/fetcher_spec.rb:260`).

## Test plan

- [ ] Verify the [webhooks guide](https://signalwire.com/docs/compatibility-api/guides/webhooks#parameters) renders correctly with `ot` parameter name and updated defaults
- [ ] Verify the [common webhook errors page](https://signalwire.com/docs/compatibility-api/guides/common-webhook-errors) shows "2 seconds for Connect"
- [ ] Product decision needed on `tt` parameter — implement or remove from docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)