### PR TITLE
Consolidate uuid scalar usage across REST specs

### DIFF
--- a/fern/apis/compatibility/openapi.yaml
+++ b/fern/apis/compatibility/openapi.yaml
@@ -853,8 +853,7 @@ paths:
           required: false
           description: The unique identifier for the call that created this call.
           schema:
-            type: string
-            format: uuid
+            $ref: '#/components/schemas/uuid'
           explode: false
         - name: StartTime
           in: query
@@ -4165,16 +4164,14 @@ paths:
           required: false
           description: Filter by recordings associated with a specific call.
           schema:
-            type: string
-            format: uuid
+            $ref: '#/components/schemas/uuid'
           explode: false
         - name: ConferenceSid
           in: query
           required: false
           description: Filter by recordings associated with a specific conference.
           schema:
-            type: string
-            format: uuid
+            $ref: '#/components/schemas/uuid'
           explode: false
         - name: Page
           in: query
@@ -4768,160 +4765,140 @@ components:
       required: true
       description: The Project ID that uniquely identifies the Project to retrieve.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     AccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The Account ID that has the Application.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     ApplicationPathSid:
       name: Sid
       in: path
       required: true
       description: The Application ID that uniquely identifies the Application.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     AvailablePhoneNumbersAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The Project ID that uniquely identifies the Account to retrieve.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     CallSidPath:
       name: Sid
       in: path
       required: true
       description: The unique identifier for the call.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     CallSidPathForRecording:
       name: CallSid
       in: path
       required: true
       description: The unique identifier for the call.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     CallsAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The Project ID that uniquely identifies the Account.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     ConferenceRecordingSidPath:
       name: Sid
       in: path
       required: true
       description: The unique identifier for the recording.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     ConferenceSidPath:
       name: Sid
       in: path
       required: true
       description: The unique identifier for this conference.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     ConferenceSidPathForParticipant:
       name: ConferenceSid
       in: path
       required: true
       description: The unique identifier for the conference this participant is in.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     ConferenceStreamSidPath:
       name: Sid
       in: path
       required: true
       description: The unique identifier for the stream.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     ConferencesAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The unique identifier for the account that created this conference.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     CxmlScriptSidPath:
       name: Sid
       in: path
       required: true
       description: The unique identifier of the cXML script.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     CxmlScriptsAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The unique identifier for the account this script is associated with.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     FaxSidPath:
       name: Sid
       in: path
       required: true
       description: The Fax ID that uniquely identifies the Fax.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     FaxSidPathForMedia:
       name: FaxSid
       in: path
       required: true
       description: The Fax ID that uniquely identifies the Fax.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     FaxesAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The Project ID that uniquely identifies the Account.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     ImportedPhoneNumbersAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The unique identifier for the account that is associated with this phone number.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     IncomingPhoneNumberSidPath:
       name: Sid
       in: path
       required: true
       description: The unique identifier of the phone number.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     IncomingPhoneNumbersAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The unique identifier for the account that is associated with this phone number.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     IsoCountryPath:
       name: IsoCountry
       in: path
@@ -4935,32 +4912,28 @@ components:
       required: true
       description: A unique ID that identifies this specific message.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     MessageSidPathForMedia:
       name: MessageSid
       in: path
       required: true
       description: A unique ID that identifies this specific message.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     MessagesAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The unique identifier of the project that sent or received this message.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     ParticipantCallSidPath:
       name: CallSid
       in: path
       required: true
       description: The unique identifier for the Participant call connected to this conference.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     QueueMemberCallSidPath:
       name: CallSid
       in: path
@@ -4974,72 +4947,63 @@ components:
       required: true
       description: The unique identifier for the queue.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     QueueSidPathForMembers:
       name: QueueSid
       in: path
       required: true
       description: The unique identifier for the queue.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     QueuesAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The unique identifier for the account this Queue is associated with.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     RecordingSidPath:
       name: Sid
       in: path
       required: true
       description: The unique identifier for the recording.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     RecordingsAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The unique identifier for the account that is associated with this recording.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     TokenIdPath:
       name: token_id
       in: path
       required: true
       description: The unique identifier of the project API token.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     TokensAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The unique identifier for the project you want to use to authenticate this request.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     TranscriptionSidPath:
       name: Sid
       in: path
       required: true
       description: The unique identifier for the transcription.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     TranscriptionsAccountSidPath:
       name: AccountSid
       in: path
       required: true
       description: The unique identifier for the account that created this transcription.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
   schemas:
     Account:
       type: object
@@ -5059,8 +5023,8 @@ components:
         - subresource_uris
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for this Project.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -5093,8 +5057,8 @@ components:
             - $ref: '#/components/schemas/AccountType'
           description: The type of the Project. Always 'Full'.
         owner_account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The Project ID of the parent project. For parent projects, this is the same as sid.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -5200,8 +5164,8 @@ components:
         - subresource_uris
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for this Project.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -5234,8 +5198,8 @@ components:
             - $ref: '#/components/schemas/AccountType'
           description: The type of the Project. Always 'Full'.
         owner_account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The Project ID of the parent project. For parent projects, this is the same as sid.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -5318,14 +5282,14 @@ components:
         - message_status_callback
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the Application.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the Account that created this Application.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -5536,14 +5500,14 @@ components:
         - message_status_callback
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the Application.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the Account that created this Application.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -5880,14 +5844,14 @@ components:
         - audio_out_lost
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the call.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ca
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that created this call.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -5903,9 +5867,8 @@ components:
             - Wed, 19 Sep 2018 21:00:00 +0000
         parent_call_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the call that created this call.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -5941,9 +5904,8 @@ components:
             - (310) 338-4645
         phone_number_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the phone number.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472pn
@@ -6196,14 +6158,14 @@ components:
         - trim
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the recording.
           examples:
             - 19e436af-5688-4307-b03b-bdb2b42b8142
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that is associated with this recording.
           examples:
             - 720796a0-8ee9-4350-83bd-2d07a3121f1e
@@ -6214,17 +6176,15 @@ components:
             - '2010-04-01'
         call_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the call that is associated with this recording. Null if this is a conference recording.
           examples:
             - 43bb71ee-553f-4074-bb20-8e2747647cce
         conference_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the conference that is associated with this recording. Null if this is a call recording.
           examples:
             - null
@@ -6366,14 +6326,14 @@ components:
         - audio_out_lost
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the call.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ca
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that created this call.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -6389,9 +6349,8 @@ components:
             - Wed, 19 Sep 2018 21:00:00 +0000
         parent_call_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the call that created this call.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -6427,9 +6386,8 @@ components:
             - (310) 338-4645
         phone_number_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the phone number.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472pn
@@ -6619,20 +6577,20 @@ components:
         - uri
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the stream.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472st
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
         call_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the call.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ca
@@ -6823,14 +6781,14 @@ components:
         - subresource_uris
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for this conference.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472cf
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that created this conference.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -6948,22 +6906,21 @@ components:
         - uri
       properties:
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that created this conference.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
         call_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the Participant call connected to this conference.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ca
         call_sid_to_coach:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier of the participant who is being coached.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472co
@@ -6973,8 +6930,8 @@ components:
           examples:
             - false
         conference_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the conference this participant is in.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472cf
@@ -7093,22 +7050,21 @@ components:
         - uri
       properties:
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that created this conference.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
         call_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the Participant call connected to this conference.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ca
         call_sid_to_coach:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier of the participant who is being coached.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472co
@@ -7118,8 +7074,8 @@ components:
           examples:
             - false
         conference_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the conference this participant is in.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472cf
@@ -7191,14 +7147,14 @@ components:
         - trim
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the recording.
           examples:
             - 19e436af-5688-4307-b03b-bdb2b42b8142
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that is associated with this recording.
           examples:
             - 720796a0-8ee9-4350-83bd-2d07a3121f1e
@@ -7216,9 +7172,8 @@ components:
             - null
         conference_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the conference that is associated with this recording.
           examples:
             - 43bb71ee-553f-4074-bb20-8e2747647cce
@@ -7400,14 +7355,14 @@ components:
         - trim
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the recording.
           examples:
             - 19e436af-5688-4307-b03b-bdb2b42b8142
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that is associated with this recording.
           examples:
             - 720796a0-8ee9-4350-83bd-2d07a3121f1e
@@ -7425,9 +7380,8 @@ components:
             - null
         conference_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the conference that is associated with this recording.
           examples:
             - 43bb71ee-553f-4074-bb20-8e2747647cce
@@ -7573,14 +7527,14 @@ components:
         - subresource_uris
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for this conference.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472cf
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that created this conference.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -7644,14 +7598,14 @@ components:
         - uri
       properties:
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
         conference_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the conference.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472cf
@@ -7668,8 +7622,8 @@ components:
           examples:
             - my_conference_stream
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the stream.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472st
@@ -7948,8 +7902,8 @@ components:
           examples:
             - http://your-application.com/docs/voice.xml
         ApplicationSid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier of the application used to handle the call. Required if `Url` and `Laml`/`Twiml` are not used.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ap
@@ -8373,8 +8327,8 @@ components:
           examples:
             - My Business Line
         SmsApplicationSid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the application associated with SMS handling on this phone number.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472sa
@@ -8424,8 +8378,8 @@ components:
             - POST
           default: POST
         VoiceApplicationSid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the application associated with call handling on this phone number.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472va
@@ -8507,8 +8461,8 @@ components:
           examples:
             - false
         ApplicationSid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The SID of a SignalWire cXML Application used to configure the message's status callback.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ap
@@ -8534,8 +8488,8 @@ components:
             - 14400
           default: 14400
         MessagingServiceSid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of a number group to use when sending the message. Either `From` or `MessagingServiceSid` must be provided.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ms
@@ -8601,8 +8555,8 @@ components:
               - fax
               - messaging
         subproject_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier of the subproject you would like to create a token for. Must belong to the parent project.
           examples:
             - 9a7fc048-984f-11ee-b9d1-0242ac120002
@@ -8625,8 +8579,8 @@ components:
         - uri
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier of the cXML script on SignalWire.
           examples:
             - 5184b831-184f-4209-872d-ccdccc80f2f1
@@ -8648,8 +8602,8 @@ components:
           examples:
             - '2020-06-05T20:00:00Z'
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account this script is associated with.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -8759,8 +8713,8 @@ components:
         - uri
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier of the cXML script on SignalWire.
           examples:
             - 5184b831-184f-4209-872d-ccdccc80f2f1
@@ -8782,8 +8736,8 @@ components:
           examples:
             - '2020-06-05T20:00:00Z'
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account this script is associated with.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -9425,14 +9379,14 @@ components:
         - voice_url
       properties:
         account_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that is associated with this phone number.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ac
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that is associated with this phone number.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ac
@@ -9738,14 +9692,14 @@ components:
         - voice_url
       properties:
         account_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that is associated with this phone number.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ac
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that is associated with this phone number.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ac
@@ -9953,8 +9907,8 @@ components:
         - subresource_uris
       properties:
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier of the project that sent or received this message.
           examples:
             - ea108133-d6b3-407c-9536-9fad8a929a6a
@@ -10036,8 +9990,8 @@ components:
           examples:
             - USD
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: A unique ID that identifies this specific message.
           examples:
             - 0a059168-ead0-41af-9d1f-343dae832527
@@ -10052,9 +10006,8 @@ components:
             - '+15557654321'
         messaging_service_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: If a number group was used when sending an outbound message, the number group's ID will be present, or null otherwise.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ms
@@ -10145,8 +10098,8 @@ components:
         - uri
       properties:
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account.
           examples:
             - ea108133-d6b3-407c-9536-9fad8a929a6a
@@ -10166,14 +10119,14 @@ components:
           examples:
             - Mon, 13 Aug 2018 21:38:46 +0000
         parent_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the message.
           examples:
             - 0a059168-ead0-41af-9d1f-343dae832527
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the media.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472me
@@ -10252,8 +10205,8 @@ components:
         - uri
       properties:
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account.
           examples:
             - ea108133-d6b3-407c-9536-9fad8a929a6a
@@ -10273,14 +10226,14 @@ components:
           examples:
             - Mon, 13 Aug 2018 21:38:46 +0000
         parent_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the message.
           examples:
             - 0a059168-ead0-41af-9d1f-343dae832527
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the media.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472me
@@ -10317,8 +10270,8 @@ components:
         - subresource_uris
       properties:
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier of the project that sent or received this message.
           examples:
             - ea108133-d6b3-407c-9536-9fad8a929a6a
@@ -10400,8 +10353,8 @@ components:
           examples:
             - USD
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: A unique ID that identifies this specific message.
           examples:
             - 0a059168-ead0-41af-9d1f-343dae832527
@@ -10416,9 +10369,8 @@ components:
             - '+15557654321'
         messaging_service_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: If a number group was used when sending an outbound message, the number group's ID will be present, or null otherwise.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ms
@@ -10524,14 +10476,14 @@ components:
         - uri
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the queue.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472qu
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account this Queue is associated with.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -10653,20 +10605,20 @@ components:
         - uri
       properties:
         call_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the call.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ca
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
         queue_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the queue.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472qu
@@ -10770,20 +10722,20 @@ components:
         - uri
       properties:
         call_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the call.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ca
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
         queue_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the queue.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472qu
@@ -10834,14 +10786,14 @@ components:
         - uri
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the queue.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472qu
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account this Queue is associated with.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472af
@@ -10921,14 +10873,14 @@ components:
         - trim
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the recording.
           examples:
             - 19e436af-5688-4307-b03b-bdb2b42b8142
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that is associated with this recording.
           examples:
             - 720796a0-8ee9-4350-83bd-2d07a3121f1e
@@ -10939,17 +10891,15 @@ components:
             - '2010-04-01'
         call_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the call that is associated with this recording. Null if this is a conference recording.
           examples:
             - 43bb71ee-553f-4074-bb20-8e2747647cce
         conference_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the conference that is associated with this recording. Null if this is a call recording.
           examples:
             - null
@@ -11132,14 +11082,14 @@ components:
         - trim
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the recording.
           examples:
             - 19e436af-5688-4307-b03b-bdb2b42b8142
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that is associated with this recording.
           examples:
             - 720796a0-8ee9-4350-83bd-2d07a3121f1e
@@ -11150,17 +11100,15 @@ components:
             - '2010-04-01'
         call_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the call that is associated with this recording. Null if this is a conference recording.
           examples:
             - 43bb71ee-553f-4074-bb20-8e2747647cce
         conference_sid:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier for the conference that is associated with this recording. Null if this is a call recording.
           examples:
             - null
@@ -11518,8 +11466,8 @@ components:
         - token
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier of the created API Token.
           examples:
             - ea14556a-984f-11ee-b9d1-0242ac120002
@@ -11564,14 +11512,14 @@ components:
         - uri
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the transcription.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472tr
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that created this transcription.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ac
@@ -11581,8 +11529,8 @@ components:
           examples:
             - '2010-04-01'
         recording_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the recording that this transcription was created from.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472re
@@ -11713,14 +11661,14 @@ components:
         - uri
       properties:
         sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the transcription.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472tr
         account_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the account that created this transcription.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ac
@@ -11730,8 +11678,8 @@ components:
           examples:
             - '2010-04-01'
         recording_sid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the recording that this transcription was created from.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472re
@@ -12028,8 +11976,8 @@ components:
           examples:
             - false
         CallSidToCoach:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier of the participant who is being coached. Required when `Coaching` is true.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472co
@@ -12183,14 +12131,14 @@ components:
       type: object
       properties:
         AccountSid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for an account to which the number should be transferred. Must be within the same Space.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ac
         EmergencyAddressSid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier of the address associated with E911 for this phone number. Not supported for toll-free numbers or certain providers.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ad
@@ -12202,8 +12150,8 @@ components:
           examples:
             - My Business Line
         SmsApplicationSid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the application associated with SMS handling on this phone number.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472sa
@@ -12253,8 +12201,8 @@ components:
             - POST
           default: POST
         VoiceApplicationSid:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier for the application associated with call handling on this phone number.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472va
@@ -12379,6 +12327,10 @@ components:
       unevaluatedProperties:
         not: {}
       description: Request body for updating an API token.
+    uuid:
+      type: string
+      format: uuid
+      description: Universal Unique Identifier.
   securitySchemes:
     SignalWireBasicAuth:
       type: http

--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -6262,8 +6262,7 @@ paths:
           required: true
           description: The unique identifier of the token to update.
           schema:
-            type: string
-            format: uuid
+            $ref: '#/components/schemas/uuid'
       responses:
         '200':
           description: The request has succeeded.
@@ -6320,8 +6319,7 @@ paths:
           required: true
           description: The unique identifier of the token that you want to delete.
           schema:
-            type: string
-            format: uuid
+            $ref: '#/components/schemas/uuid'
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
@@ -10326,7 +10324,6 @@ paths:
             type: integer
             format: int32
             minimum: 0
-            exclusiveMinimum: true
           explode: false
       responses:
         '200':
@@ -10932,8 +10929,7 @@ paths:
           required: true
           description: Unique ID of the room.
           schema:
-            type: string
-            format: uuid
+            $ref: '#/components/schemas/uuid'
         - name: include_active_session
           in: query
           required: false
@@ -10997,8 +10993,7 @@ paths:
           required: true
           description: Unique ID of the room.
           schema:
-            type: string
-            format: uuid
+            $ref: '#/components/schemas/uuid'
       responses:
         '200':
           description: The request has succeeded.
@@ -11061,8 +11056,7 @@ paths:
           required: true
           description: Unique ID of the room.
           schema:
-            type: string
-            format: uuid
+            $ref: '#/components/schemas/uuid'
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
@@ -11539,7 +11533,6 @@ components:
       description: Unique ID of a AI Agent.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     AIAgentPathID:
       name: id
       in: path
@@ -11555,7 +11548,6 @@ components:
       description: Unique ID of the address.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     AssignedNumberPathID:
       name: id
       in: path
@@ -11563,7 +11555,6 @@ components:
       description: Unique ID of the assigned number.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     BrandPathID:
       name: id
       in: path
@@ -11571,15 +11562,13 @@ components:
       description: Unique ID of the brand.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     CXMLScriptAddressPathID:
       name: id
       in: path
       required: true
       description: The unique identifier of the cXML Script.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     CXMLScriptPathID:
       name: id
       in: path
@@ -11603,7 +11592,6 @@ components:
       description: Unique ID of a CXML Webhook.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     CallFlowAddressPathID:
       name: id
       in: path
@@ -11611,7 +11599,6 @@ components:
       description: The unique identifier of the Call Flow.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     CallFlowPathID:
       name: id
       in: path
@@ -11619,7 +11606,6 @@ components:
       description: Unique ID of a Call Flow.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     CallFlowVersionPathID:
       name: id
       in: path
@@ -11634,7 +11620,6 @@ components:
       description: Unique ID of the campaign.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     ConferenceRoomAddressPathID:
       name: id
       in: path
@@ -11642,7 +11627,6 @@ components:
       description: The unique identifier of the Conference Room.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     ConferenceRoomPathID:
       name: id
       in: path
@@ -11650,15 +11634,13 @@ components:
       description: Unique ID of a Conference Room.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     CxmlApplicationAddressPathID:
       name: id
       in: path
       required: true
       description: The unique identifier of the cXML Application.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     CxmlApplicationPathID:
       name: id
       in: path
@@ -11711,7 +11693,7 @@ components:
       required: true
       description: Unique ID of the parent Document.
       schema:
-        $ref: '#/components/schemas/Datasphere.docid'
+        $ref: '#/components/schemas/uuid'
     Datasphere.DocumentListQuery.page_number:
       name: page_number
       in: query
@@ -11749,22 +11731,21 @@ components:
       required: true
       description: Unique ID of the Document.
       schema:
-        $ref: '#/components/schemas/Datasphere.docid'
+        $ref: '#/components/schemas/uuid'
     Datasphere.PathID:
       name: id
       in: path
       required: true
       description: Unique ID of a Document.
       schema:
-        $ref: '#/components/schemas/Datasphere.docid'
+        $ref: '#/components/schemas/uuid'
     DialogflowAgentAddressPathID:
       name: id
       in: path
       required: true
       description: The unique identifier of the Dialogflow Agent Address.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     DialogflowAgentPathID:
       name: id
       in: path
@@ -11772,7 +11753,6 @@ components:
       description: Unique ID of a Dialogflow Agent.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     DomainApplicationPathID:
       name: id
       in: path
@@ -11780,7 +11760,6 @@ components:
       description: Unique ID of the domain application.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     E164NumberPath:
       name: e164_number
       in: path
@@ -11795,7 +11774,6 @@ components:
       description: Unique ID of a FabricAddress.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     FabricSubscriberID:
       name: fabric_subscriber_id
       in: path
@@ -11803,7 +11781,6 @@ components:
       description: Unique ID of a Fabric Subscriber.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     Fax.LogListRequest.created_after:
       name: created_after
       in: query
@@ -11875,7 +11852,6 @@ components:
       description: Unique ID of the log
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     FreeswitchConnectorAddressPathID:
       name: id
       in: path
@@ -11883,7 +11859,6 @@ components:
       description: The unique identifier of the FreeSWITCH Connector.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     FreeswitchConnectorPathID:
       name: id
       in: path
@@ -11891,7 +11866,6 @@ components:
       description: Unique ID of a FreeSWITCH Connector.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     ListAddressesQuery.filter_label:
       name: filter_label
       in: query
@@ -12317,15 +12291,13 @@ components:
       description: Unique ID of the log.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     Message.MessagePathID:
       name: message_id
       in: path
       required: true
       description: The message segment ID — the same ID returned by the create endpoint and shown in `/api/messaging/logs`.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     MfaRequestIdPath:
       name: mfa_request_id
       in: path
@@ -12333,7 +12305,6 @@ components:
       description: The MFA request ID.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     NumberGroupIdPath:
       name: NumberGroupId
       in: path
@@ -12341,7 +12312,6 @@ components:
       description: Unique ID of the number group.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     NumberGroupMembershipPathID:
       name: id
       in: path
@@ -12349,7 +12319,6 @@ components:
       description: Unique ID of the number group membership.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     NumberGroupPathID:
       name: id
       in: path
@@ -12357,7 +12326,6 @@ components:
       description: Unique ID of the number group.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     OrderPathID:
       name: id
       in: path
@@ -12365,7 +12333,6 @@ components:
       description: Unique ID of the order.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     PhoneNumberPathID:
       name: id
       in: path
@@ -12373,7 +12340,6 @@ components:
       description: Unique ID of the phone number.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     PhoneRoutePathID:
       name: id
       in: path
@@ -12381,7 +12347,6 @@ components:
       description: The unique identifier of the Resource.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     QueueIdPath:
       name: queue_id
       in: path
@@ -12389,7 +12354,6 @@ components:
       description: Unique ID of the queue.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     QueueMemberPathID:
       name: id
       in: path
@@ -12397,7 +12361,6 @@ components:
       description: The unique identifier (ID) of the queue member.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     QueuePathID:
       name: id
       in: path
@@ -12405,7 +12368,6 @@ components:
       description: Unique ID of the queue.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     RecordingPathID:
       name: id
       in: path
@@ -12413,15 +12375,13 @@ components:
       description: Unique ID of the recording.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     RelayApplicationAddressPathID:
       name: id
       in: path
       required: true
       description: The unique identifier of the Relay Application.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     RelayApplicationPathID:
       name: id
       in: path
@@ -12429,7 +12389,6 @@ components:
       description: Unique ID of a Relay Application.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     ResourceAddressPathID:
       name: id
       in: path
@@ -12437,7 +12396,6 @@ components:
       description: The unique identifier of the Resource.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     ResourcePathID:
       name: id
       in: path
@@ -12445,7 +12403,6 @@ components:
       description: Unique ID of a Resource.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     ResourceSipEndpointPathID:
       name: id
       in: path
@@ -12453,7 +12410,6 @@ components:
       description: The unique identifier of the Resource.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     SIPEndpointID:
       name: id
       in: path
@@ -12461,15 +12417,13 @@ components:
       description: Unique ID of a Sip Endpoint.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     SWMLScriptAddressPathID:
       name: id
       in: path
       required: true
       description: The unique identifier of the SWML Script.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     SWMLWebhookID:
       name: id
       in: path
@@ -12485,7 +12439,6 @@ components:
       description: Unique ID of a SWML Webhook.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     ShortCodePathID:
       name: id
       in: path
@@ -12493,7 +12446,6 @@ components:
       description: Unique ID of the short code.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     SipEndpointAddressPathID:
       name: id
       in: path
@@ -12501,7 +12453,6 @@ components:
       description: The unique identifier of the SIP Endpoint.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     SipEndpointPathID:
       name: id
       in: path
@@ -12509,7 +12460,6 @@ components:
       description: Unique ID of the SIP endpoint.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     SipGatewayAddressRequest:
       name: id
       in: path
@@ -12517,7 +12467,6 @@ components:
       description: The unique identifier of the SIP Gateway.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     SipGatewayID:
       name: id
       in: path
@@ -12525,7 +12474,6 @@ components:
       description: Unique ID of a SIP Gateway.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     SubscriberAddressID:
       name: id
       in: path
@@ -12533,7 +12481,6 @@ components:
       description: Unique ID of a Subscriber Address.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     SubscriberPathID:
       name: id
       in: path
@@ -12541,7 +12488,6 @@ components:
       description: Unique ID of a Subscriber.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     SwmlScriptPathID:
       name: id
       in: path
@@ -12557,23 +12503,20 @@ components:
       description: Unique ID of the verified caller ID.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
     Video.ConferencePathID:
       name: id
       in: path
       required: true
       description: Unique ID of the video conference.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     Video.ConferenceTokenPathID:
       name: id
       in: path
       required: true
       description: Unique ID of the conference token.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     Video.ListConferenceTokensRequest.page_number:
       name: page_number
       in: query
@@ -12764,7 +12707,6 @@ components:
         type: integer
         format: int32
         minimum: 0
-        exclusiveMinimum: true
       explode: false
     Video.ListRoomRecordingsRequest.page_number:
       name: page_number
@@ -12868,7 +12810,6 @@ components:
         type: integer
         format: int32
         minimum: 0
-        exclusiveMinimum: true
       explode: false
     Video.ListRoomSessionRecordingsRequest.page_number:
       name: page_number
@@ -12938,8 +12879,7 @@ components:
       required: false
       description: Return Sessions started from this Room.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
       explode: false
     Video.ListRoomSessionsRequest.room_name:
       name: room_name
@@ -12971,40 +12911,35 @@ components:
       required: true
       description: Unique ID of the log.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     Video.RoomPathID:
       name: id
       in: path
       required: true
       description: Unique ID of the video room.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     Video.RoomRecordingPathID:
       name: id
       in: path
       required: true
       description: Unique ID of the Room Recording.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     Video.RoomSessionPathID:
       name: id
       in: path
       required: true
       description: Unique ID of the Room Session.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     Video.StreamPathID:
       name: id
       in: path
       required: true
       description: Unique ID of the stream.
       schema:
-        type: string
-        format: uuid
+        $ref: '#/components/schemas/uuid'
     Voice.LogListRequest.created_after:
       name: created_after
       in: query
@@ -13076,7 +13011,6 @@ components:
       description: Unique ID of the log. This is the segment_id you can find in Relay call details in your Dashboard UI or in return objects when using the SDK.
       schema:
         $ref: '#/components/schemas/uuid'
-        format: uuid
   schemas:
     AI:
       type: object
@@ -13384,14 +13318,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the AIAgent.
           examples:
             - a87db7ed-8ebe-42e4-829f-8ba5a4152f54
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 99151cf8-9548-4860-ba70-a8de824f3312
@@ -15091,7 +15023,6 @@ components:
         phone_number_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The phone number ID to add to the group.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -15118,7 +15049,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the Address on SignalWire.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -15232,7 +15162,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the Address on SignalWire.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -15475,7 +15404,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the assignment.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -15487,7 +15415,6 @@ components:
         campaign_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The campaign ID associated with the number.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -15527,7 +15454,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the phone number.
         name:
           type: string
@@ -16334,7 +16260,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the brand.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -16440,7 +16365,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the brand.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -16736,14 +16660,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the cXML Script.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -17123,14 +17045,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the CXMLWebhook.
           examples:
             - a87db7ed-8ebe-42e4-829f-8ba5a4152f54
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 99151cf8-9548-4860-ba70-a8de824f3312
@@ -17265,7 +17185,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of a Call Flow.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -17405,14 +17324,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Call Flow.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -17494,7 +17411,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the version.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -17547,7 +17463,6 @@ components:
         call_flow_version_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Any call flow version ID for this call flow.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -17569,7 +17484,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the deployed Call Flow Version.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
@@ -21256,7 +21170,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the campaign.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -21425,7 +21338,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the campaign.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -21925,7 +21837,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique id of the Conference Room
           examples:
             - 1bd571e4-5ea4-4a70-a3c8-2bab5d20e754
@@ -22263,14 +22174,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Conference Room.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -23903,7 +23812,6 @@ components:
         call_video_room_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A string representing the ID of the Video Room to forward incoming calls to. Required when call_handler is video_room.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -23915,21 +23823,18 @@ components:
         call_dialogflow_agent_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A string representing the ID of the Dialogflow Agent to forward incoming calls to. Required when call_handler is dialogflow.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
         call_ai_agent_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A string representing the ID of the AI Agent to forward incoming calls to. Required when call_handler is ai_agent.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
         call_flow_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A string representing the ID of the Call Flow to forward incoming calls to. Required when call_handler is call_flow.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -24066,7 +23971,6 @@ components:
         brand_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The ID of the brand to associate with this campaign.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -24258,7 +24162,6 @@ components:
         brand_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The ID of the brand to associate with this campaign. Must be a CSP/partner brand.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -24420,19 +24323,19 @@ components:
           examples:
             - my-relay-app
         call_video_room_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the Video Room to forward incoming calls to. Required when call_handler is video_room.
         call_flow_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the Call Flow to forward incoming calls to. Required when call_handler is call_flow.
         call_flow_version:
           type: string
           description: The version of the Call Flow to use. Valid values are 'working_copy' or 'current_deployed'.
         call_ai_agent_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the AI Agent to forward incoming calls to. Required when call_handler is ai_agent.
         call_relay_script_url:
           type: string
@@ -24727,14 +24630,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the cXML Application.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -24937,7 +24838,7 @@ components:
             - Cristiano Ronaldo is the highest-paid football player in the world in 2024
         document_id:
           allOf:
-            - $ref: '#/components/schemas/Datasphere.docid'
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the Document.
           examples:
             - acaa5c49-be5e-4477-bce0-48f4b23b7720
@@ -25112,7 +25013,7 @@ components:
       properties:
         id:
           allOf:
-            - $ref: '#/components/schemas/Datasphere.docid'
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the Document.
           examples:
             - acaa5c49-be5e-4477-bce0-48f4b23b7720
@@ -25342,7 +25243,7 @@ components:
               - game
         document_id:
           allOf:
-            - $ref: '#/components/schemas/Datasphere.docid'
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of a Document.
           examples:
             - acaa5c49-be5e-4477-bce0-48f4b23b7720
@@ -25524,10 +25425,6 @@ components:
               message: Invalid tags
               attribute: tags
               url: https://signalwire.com/docs/apis/error-codes
-    Datasphere.docid:
-      type: string
-      format: uuid
-      description: Unique ID of a Document.
     Denoise:
       type: object
       required:
@@ -25694,7 +25591,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of a Dialogflow Agent.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -25721,7 +25617,6 @@ components:
         dialogflow_reference_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Dialogflow reference ID
           examples:
             - 12345678-1234-1234-1234-1234567890ab
@@ -25812,14 +25707,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Dialogflow Agent.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -25978,7 +25871,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the domain application on SignalWire.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -26026,7 +25918,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier of the calling handler resource.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -26114,7 +26005,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: A string representing the ID of the Video Room to forward incoming calls to.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -26155,7 +26045,6 @@ components:
         domain_application_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The id of the domain application you wish to assign a resource to.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
@@ -26233,7 +26122,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the domain application on SignalWire.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -26281,7 +26169,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier of the calling handler resource.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -26369,7 +26256,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: A string representing the ID of the Video Room to forward incoming calls to.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -26883,7 +26769,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Fabric Address.
           examples:
             - 691af061-cd86-4893-a605-173f47afc4c2
@@ -26942,7 +26827,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Fabric Address.
           examples:
             - 691af061-cd86-4893-a605-173f47afc4c2
@@ -27007,7 +26891,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Fabric Address.
           examples:
             - 691af061-cd86-4893-a605-173f47afc4c2
@@ -27104,7 +26987,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Fabric Address.
           examples:
             - 691af061-cd86-4893-a605-173f47afc4c2
@@ -27169,7 +27051,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Fabric Address.
           examples:
             - 691af061-cd86-4893-a605-173f47afc4c2
@@ -27251,7 +27132,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The id of the Sip Endpoint
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
@@ -27357,7 +27237,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A unique identifier for the log
           examples:
             - b7182dc2-00f3-40e4-a5ce-20f164b329df
@@ -27592,7 +27471,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A unique identifier for the log
           examples:
             - b7182dc2-00f3-40e4-a5ce-20f164b329df
@@ -27757,7 +27635,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of a FreeSWITCH Connector.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -27845,7 +27722,6 @@ components:
         token:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: FreeSWITCH token
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
@@ -27903,14 +27779,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the FreeSWITCH Connector.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -30385,8 +30259,8 @@ components:
         - updated_at
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique identifier for the conference.
           examples:
             - b9028451-b1d3-4690-b5d3-37b19d25f573
@@ -30467,8 +30341,8 @@ components:
         - created_at
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique identifier for the conference.
           examples:
             - b9028451-b1d3-4690-b5d3-37b19d25f573
@@ -30567,8 +30441,8 @@ components:
         - type
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique identifier for the conference.
           examples:
             - b9028451-b1d3-4690-b5d3-37b19d25f573
@@ -30650,8 +30524,8 @@ components:
         - recording_file_size
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique identifier for the conference.
           examples:
             - b9028451-b1d3-4690-b5d3-37b19d25f573
@@ -30753,8 +30627,8 @@ components:
         - charge_details
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique identifier for the conference.
           examples:
             - b9028451-b1d3-4690-b5d3-37b19d25f573
@@ -30837,7 +30711,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the phone number.
         name:
           type: string
@@ -30991,7 +30864,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A unique identifier for the log.
         from:
           type: string
@@ -31107,7 +30979,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique ID of the message. This is the `MessageSegment` ID, consistent with the dashboard and the `/api/messaging/logs` endpoint.
           examples:
             - c2d3e4f5-a6b7-8901-cdef-234567890abc
@@ -31181,7 +31052,6 @@ components:
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The ID of the project the message belongs to.
           examples:
             - a1b2c3d4-e5f6-7890-abcd-ef1234567890
@@ -31233,7 +31103,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A unique identifier for the log.
         from:
           type: string
@@ -31596,7 +31465,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The MFA request ID. Save this for verification.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -31674,7 +31542,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the Number Group on SignalWire. This can be used to update or delete the group programmatically.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -31727,14 +31594,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the Number Group Membership on SignalWire. This can be used to delete the membership programmatically.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
         number_group_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the Number Group this membership is associated with.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -31785,14 +31650,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the Number Group Membership on SignalWire. This can be used to delete the membership programmatically.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
         number_group_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the Number Group this membership is associated with.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -31824,7 +31687,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the Number Group on SignalWire. This can be used to update or delete the group programmatically.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -31963,7 +31825,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the order.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -32015,7 +31876,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the order.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -32425,7 +32285,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the phone number.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -32456,7 +32315,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The E911 address ID associated with this phone number.
         created_at:
           type: string
@@ -32483,7 +32341,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier of the calling handler resource.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -32590,7 +32447,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The ID of the Relay SIP Endpoint to send this call to when using the relay_sip_endpoint call handler.
         call_verto_resource:
           anyOf:
@@ -32601,7 +32457,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The ID of the Video Room to send this call to when using the video_room call handler.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -32616,7 +32471,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier of the messaging handler resource.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -32876,7 +32730,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the phone number.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -32907,7 +32760,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The E911 address ID associated with this phone number.
         created_at:
           type: string
@@ -32934,7 +32786,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier of the calling handler resource.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -33041,7 +32892,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The ID of the Relay SIP Endpoint to send this call to when using the relay_sip_endpoint call handler.
         call_verto_resource:
           anyOf:
@@ -33052,7 +32902,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The ID of the Video Room to send this call to when using the video_room call handler.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -33067,7 +32916,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier of the messaging handler resource.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -33137,7 +32985,6 @@ components:
         phone_route_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The id of the phone route.
           examples:
             - 691af061-cd86-4893-a605-173f47afc4c2
@@ -33186,7 +33033,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Fabric Address.
           examples:
             - 691af061-cd86-4893-a605-173f47afc4c2
@@ -33542,8 +33388,8 @@ components:
               - fax
               - messaging
         subproject_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The unique identifier of the subproject you would like to create a token for. The subproject passed must be a child of the project used to authenticate the request.
           examples:
             - 9a7fc048-984f-11ee-b9d1-0242ac120002
@@ -33574,8 +33420,8 @@ components:
         - token
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the created API Token.
           examples:
             - ea14556a-984f-11ee-b9d1-0242ac120002
@@ -33839,14 +33685,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the recording.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the project.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
@@ -33907,7 +33751,6 @@ components:
         relay_pstn_leg_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: ID of the PSTN leg associated with the recording.
       unevaluatedProperties:
         not: {}
@@ -34077,14 +33920,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the queue.
           examples:
             - aae131db-214c-46f5-88b6-92004f8467cf
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The project ID associated with this queue.
           examples:
             - c6c4679b-716a-456a-9e41-a03821005005
@@ -34154,7 +33995,6 @@ components:
         call_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The call ID of the queue member.
           examples:
             - 596e2dea-a269-4765-a0b4-01b82d11c120
@@ -34219,7 +34059,6 @@ components:
         call_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The call ID of the queue member.
           examples:
             - 596e2dea-a269-4765-a0b4-01b82d11c120
@@ -34267,14 +34106,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the queue.
           examples:
             - aae131db-214c-46f5-88b6-92004f8467cf
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The project ID associated with this queue.
           examples:
             - c6c4679b-716a-456a-9e41-a03821005005
@@ -34623,7 +34460,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of a Relay Application.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -34767,14 +34603,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Relay Application.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35058,14 +34892,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35114,14 +34946,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35170,14 +35000,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35226,14 +35054,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35282,14 +35108,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35338,14 +35162,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35394,14 +35216,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35450,14 +35270,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35506,14 +35324,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35562,14 +35378,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35618,14 +35432,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35674,14 +35486,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35730,14 +35540,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35786,14 +35594,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Resource.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -35836,7 +35642,6 @@ components:
         sip_endpoint_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the SIP endpoint.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -35877,7 +35682,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the SIP endpoint.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -36699,14 +36503,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the SWML Webhook.
           examples:
             - a87db7ed-8ebe-42e4-829f-8ba5a4152f54
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 99151cf8-9548-4860-ba70-a8de824f3312
@@ -37008,7 +36810,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the short code.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -37102,7 +36903,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The ID of the LāML application to handle messages when using laml_application handler.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -37172,7 +36972,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the short code.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -37266,7 +37065,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The ID of the LāML application to handle messages when using laml_application handler.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -37323,7 +37121,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the SIP endpoint.
           examples:
             - 67075301-69b2-4fc3-8a2c-c95a69a5665e
@@ -37374,7 +37171,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier of the calling handler resource.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -37468,7 +37264,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: A string representing the ID of the Video Room to forward incoming calls to. This is only used (and required) when call_handler is set to video_room.
         call_relay_script_url:
           anyOf:
@@ -37560,7 +37355,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The id of the Sip Endpoint
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
@@ -37700,7 +37494,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the SIP endpoint.
           examples:
             - 67075301-69b2-4fc3-8a2c-c95a69a5665e
@@ -37751,7 +37544,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: The unique identifier of the calling handler resource.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -37845,7 +37637,6 @@ components:
           anyOf:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: A string representing the ID of the Video Room to forward incoming calls to. This is only used (and required) when call_handler is set to video_room.
         call_relay_script_url:
           anyOf:
@@ -37954,8 +37745,8 @@ components:
         - encryption
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the SIP Gateway.
           examples:
             - cce59cad-104d-4c28-ada4-98cfd102ae09
@@ -38200,14 +37991,14 @@ components:
         - sip_gateway
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the resource.
           examples:
             - 0823a606-0aff-4c90-9eba-f88ba118fe05
         project_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Project ID associated with the resource.
           examples:
             - bc949800-7b40-43cf-8438-a85facfcbdd1
@@ -38299,14 +38090,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the recording.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the project.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
@@ -38367,7 +38156,6 @@ components:
         relay_sip_leg_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: ID of the SIP leg associated with the recording.
       unevaluatedProperties:
         not: {}
@@ -38812,7 +38600,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Subscriber.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
@@ -38990,7 +38777,6 @@ components:
         address_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of a Subscriber Address
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -39406,7 +39192,6 @@ components:
         application_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The ID of the application that the token is associated with.
           examples:
             - 123e4567-e89b-12d3-a456-426614174000
@@ -39469,7 +39254,6 @@ components:
         subscriber_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The ID of the subscriber that the token is associated with.
           examples:
             - 32d94154-9297-418c-9a85-4a69e0c67c30
@@ -39872,14 +39656,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the SWML Script.
           examples:
             - 993ed018-9e79-4e50-b97b-984bd5534095
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the Project.
           examples:
             - 1313fe58-5e14-4c11-bbe7-6fdfa11fe780
@@ -40647,7 +40429,6 @@ components:
         call_video_room_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A string representing the ID of the Video Room to forward incoming calls to.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -40659,21 +40440,18 @@ components:
         call_dialogflow_agent_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A string representing the ID of the Dialogflow Agent to forward incoming calls to.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
         call_ai_agent_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A string representing the ID of the AI Agent to forward incoming calls to.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
         call_flow_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A string representing the ID of the Call Flow to forward incoming calls to.
           examples:
             - fe4093d9-58c2-4931-b4b9-5679f82652c6
@@ -40808,7 +40586,6 @@ components:
         call_video_room_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The ID of the Video Room to forward incoming calls to when using the video_room call handler.
         message_handler:
           allOf:
@@ -40904,7 +40681,6 @@ components:
         message_laml_application_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The ID of the LāML application to handle messages when using laml_application handler.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -41040,19 +40816,19 @@ components:
           examples:
             - my-relay-app
         call_video_room_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the Video Room to forward incoming calls to. Required when call_handler is video_room.
         call_flow_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the Call Flow to forward incoming calls to. Required when call_handler is call_flow.
         call_flow_version:
           type: string
           description: The version of the Call Flow to use. Valid values are 'working_copy' or 'current_deployed'.
         call_ai_agent_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the AI Agent to forward incoming calls to. Required when call_handler is ai_agent.
         call_relay_script_url:
           type: string
@@ -41308,7 +41084,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the Verified Caller ID on SignalWire.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -41377,7 +41152,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: The unique identifier of the Verified Caller ID on SignalWire.
           examples:
             - 3fa85f64-5717-4562-b3fc-2c963f66afa6
@@ -41599,8 +41373,8 @@ components:
         - updated_at
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the video conference.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
@@ -41890,8 +41664,8 @@ components:
         - scopes
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique identifier for the conference token.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
@@ -42401,8 +42175,8 @@ components:
         - created_at
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: A unique identifier for the log.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
@@ -42643,8 +42417,8 @@ components:
         - charge_details
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: A unique identifier for the log.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
@@ -42810,14 +42584,14 @@ components:
         - updated_at
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the Room Recording.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
         room_session_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the Room Session the Room Recording was made in.
           examples:
             - a1b2c3d4-5e6f-7890-abcd-ef1234567890
@@ -43020,8 +42794,8 @@ components:
         - updated_at
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: A unique identifier for the room.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
@@ -43200,16 +42974,15 @@ components:
         - locked_cover
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the session.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
         room_id:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: Unique ID of the Room if the Session was created from a Room and was not an auto-created Session. Null if the room was set to delete on end.
           examples:
             - a1b2c3d4-5e6f-7890-abcd-ef1234567890
@@ -43409,38 +43182,38 @@ components:
         - created_at
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the event.
           examples:
             - e44f56a8-7c69-6153-b45c-ab3456789012
         project_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the project.
           examples:
             - a1b2c3d4-5e6f-7890-abcd-ef1234567890
         room_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the room.
           examples:
             - b2c3d4e5-6f70-8901-bcde-f12345678901
         room_session_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the room session.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
         room_recording_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the associated room recording. Only present for recording-related events.
           examples:
             - d33e35f7-6b58-5042-a34b-ef2345678901
         room_participant_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: The ID of the associated room participant. Only present for participant-related events.
           examples:
             - e44f68a9-7c69-6153-b56d-ef3456789012
@@ -43479,14 +43252,14 @@ components:
         - cost_in_dollars
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the Member.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
         room_session_id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the Room Session.
           examples:
             - a1b2c3d4-5e6f-7890-abcd-ef1234567890
@@ -43567,16 +43340,15 @@ components:
         - sync_audio_video
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique ID of the session.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
         room_id:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/uuid'
             - type: 'null'
-          format: uuid
           description: Unique ID of the Room if the Session was created from a Room and was not an auto-created Session. Null if the room was set to delete on end.
           examples:
             - a1b2c3d4-5e6f-7890-abcd-ef1234567890
@@ -43821,8 +43593,8 @@ components:
         - updated_at
       properties:
         id:
-          type: string
-          format: uuid
+          allOf:
+            - $ref: '#/components/schemas/uuid'
           description: Unique identifier for the stream.
           examples:
             - c22d24f6-5a47-4597-9a23-c7d01e696b92
@@ -44296,7 +44068,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A unique identifier for the log.
           examples:
             - b7182dc2-00f3-40e4-a5ce-20f164b329df
@@ -44375,7 +44146,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A unique identifier for the log.
           examples:
             - b7182dc2-00f3-40e4-a5ce-20f164b329df
@@ -44413,7 +44183,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A unique identifier for the log.
           examples:
             - b7182dc2-00f3-40e4-a5ce-20f164b329df
@@ -44522,14 +44291,12 @@ components:
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique identifier for the project.
           examples:
             - b7182dc2-00f3-40e4-a5ce-20f164b329df
         log_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique identifier for the log.
           examples:
             - b7182dc2-00f3-40e4-a5ce-20f164b329df
@@ -44618,7 +44385,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A unique identifier for the log.
           examples:
             - b7182dc2-00f3-40e4-a5ce-20f164b329df
@@ -44745,7 +44511,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A unique identifier for the log.
           examples:
             - b7182dc2-00f3-40e4-a5ce-20f164b329df
@@ -44861,7 +44626,6 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: A unique identifier for the log.
           examples:
             - b7182dc2-00f3-40e4-a5ce-20f164b329df
@@ -44977,14 +44741,12 @@ components:
         id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the recording.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
         project_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: Unique ID of the project.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
@@ -45045,7 +44807,6 @@ components:
         relay_webrtc_leg_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          format: uuid
           description: ID of the WebRTC leg associated with the recording.
       unevaluatedProperties:
         not: {}

--- a/specs/_shared/types/main.tsp
+++ b/specs/_shared/types/main.tsp
@@ -1,1 +1,12 @@
+import "@typespec/openapi";
+
+using TypeSpec.OpenAPI;
+
 alias number = integer | float;
+
+@format("uuid")
+@doc("Universal Unique Identifier.")
+scalar uuid extends string;
+
+@format("jwt")
+scalar jwt extends string;

--- a/specs/compatibility-api/accounts/models/core.tsp
+++ b/specs/compatibility-api/accounts/models/core.tsp
@@ -3,9 +3,8 @@ using TypeSpec.Http;
 model AccountPathSid {
   @doc("The Project ID that uniquely identifies the Project to retrieve.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 @doc("The status of the Project.")
@@ -100,9 +99,8 @@ model SubresourceUris {
 @doc("Account/Project model representing a SignalWire project.")
 model Account {
   @doc("The unique identifier for this Project.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  sid: string;
+  sid: uuid;
 
   @doc("The name of the Project.")
   @example("My Project")
@@ -127,9 +125,8 @@ model Account {
   type: AccountType;
 
   @doc("The Project ID of the parent project. For parent projects, this is the same as sid.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  owner_account_sid: string;
+  owner_account_sid: uuid;
 
   @doc("The preferred region for the Project.")
   @example("us-east")

--- a/specs/compatibility-api/applications/models/core.tsp
+++ b/specs/compatibility-api/applications/models/core.tsp
@@ -3,17 +3,15 @@ using TypeSpec.Http;
 model AccountSidPath {
   @doc("The Account ID that has the Application.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model ApplicationPathSid {
   @doc("The Application ID that uniquely identifies the Application.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 @doc("HTTP method for webhooks.")
@@ -26,13 +24,11 @@ enum HttpMethod {
 model Application {
   @doc("The unique identifier for the Application.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
-  sid: string;
+  sid: uuid;
 
   @doc("The unique identifier for the Account that created this Application.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The version of the SignalWire API.")
   @example("2010-04-01")

--- a/specs/compatibility-api/available-phone-numbers/models/core.tsp
+++ b/specs/compatibility-api/available-phone-numbers/models/core.tsp
@@ -3,9 +3,8 @@ using TypeSpec.Http;
 model AvailablePhoneNumbersAccountSidPath {
   @doc("The Project ID that uniquely identifies the Account to retrieve.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model IsoCountryPath {

--- a/specs/compatibility-api/calls/main.tsp
+++ b/specs/compatibility-api/calls/main.tsp
@@ -47,9 +47,8 @@ namespace CompatibilityAPI.Calls {
 
       @query
       @doc("The unique identifier for the call that created this call.")
-      @format("uuid")
       @example("b3877c40-da60-4998-90ad-b792e98472af")
-      ParentCallSid?: string,
+      ParentCallSid?: uuid,
 
       @query
       @doc("The time, in RFC 2822 GMT format, on which the call began.")

--- a/specs/compatibility-api/calls/models/core.tsp
+++ b/specs/compatibility-api/calls/models/core.tsp
@@ -5,25 +5,22 @@ using TypeSpec.Http;
 model CallsAccountSidPath {
   @doc("The Project ID that uniquely identifies the Account.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model CallSidPath {
   @doc("The unique identifier for the call.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 model CallSidPathForRecording {
   @doc("The unique identifier for the call.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  CallSid: string;
+  CallSid: uuid;
 }
 
 @doc("Call status.")
@@ -78,14 +75,12 @@ model CallSubresourceUris {
 @doc("Call model representing a voice call.")
 model Call {
   @doc("The unique identifier for the call.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ca")
-  sid: string;
+  sid: uuid;
 
   @doc("The unique identifier for the account that created this call.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The date, in RFC 2822 GMT format, this call was created.")
   @example("Wed, 19 Sep 2018 20:00:00 +0000")
@@ -96,9 +91,8 @@ model Call {
   date_updated: string;
 
   @doc("The unique identifier for the call that created this call.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  parent_call_sid: string | null;
+  parent_call_sid: uuid | null;
 
   @doc("The address that received the call.")
   @example("+13105678901")
@@ -125,9 +119,8 @@ model Call {
   from_formatted: string;
 
   @doc("The unique identifier for the phone number.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472pn")
-  phone_number_sid: string | null;
+  phone_number_sid: uuid | null;
 
   @doc("The status of the call.")
   status: CallStatus;
@@ -225,28 +218,24 @@ model Call {
 @doc("Call recording model.")
 model CallRecording {
   @doc("The unique identifier for the recording.")
-  @format("uuid")
   @example("19e436af-5688-4307-b03b-bdb2b42b8142")
-  sid: string;
+  sid: uuid;
 
   @doc("The unique identifier for the account that is associated with this recording.")
-  @format("uuid")
   @example("720796a0-8ee9-4350-83bd-2d07a3121f1e")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The version of the SignalWire API.")
   @example("2010-04-01")
   api_version: string;
 
   @doc("The unique identifier for the call that is associated with this recording. Null if this is a conference recording.")
-  @format("uuid")
   @example("43bb71ee-553f-4074-bb20-8e2747647cce")
-  call_sid: string | null;
+  call_sid: uuid | null;
 
   @doc("The unique identifier for the conference that is associated with this recording. Null if this is a call recording.")
-  @format("uuid")
   @example(null)
-  conference_sid: string | null;
+  conference_sid: uuid | null;
 
   @doc("The number of channels in a recording (singular key). Returns '1' for mono or '2' for stereo.")
   @example("1")
@@ -313,19 +302,16 @@ model CallRecording {
 @doc("Call stream model.")
 model CallStream {
   @doc("The unique identifier for the stream.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472st")
-  sid: string;
+  sid: uuid;
 
   @doc("The unique identifier for the account.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The unique identifier for the call.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ca")
-  call_sid: string;
+  call_sid: uuid;
 
   @doc("The name of the stream.")
   @example("my_first_stream")

--- a/specs/compatibility-api/calls/models/requests.tsp
+++ b/specs/compatibility-api/calls/models/requests.tsp
@@ -18,9 +18,8 @@ model CreateCallRequest {
   Url?: string;
 
   @doc("The unique identifier of the application used to handle the call. Required if `Url` and `Laml`/`Twiml` are not used.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ap")
-  ApplicationSid?: string;
+  ApplicationSid?: uuid;
 
   // Commented out pending verification - may be internal only
   // @doc("Inline cXML/LAML document to execute. Required if `Url` and `ApplicationSid` are not used.")

--- a/specs/compatibility-api/conferences/models/core.tsp
+++ b/specs/compatibility-api/conferences/models/core.tsp
@@ -3,33 +3,29 @@ using TypeSpec.Http;
 model ConferencesAccountSidPath {
   @doc("The unique identifier for the account that created this conference.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model ConferenceSidPath {
   @doc("The unique identifier for this conference.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 model ConferenceSidPathForParticipant {
   @doc("The unique identifier for the conference this participant is in.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  ConferenceSid: string;
+  ConferenceSid: uuid;
 }
 
 model ParticipantCallSidPath {
   @doc("The unique identifier for the Participant call connected to this conference.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  CallSid: string;
+  CallSid: uuid;
 }
 
 @doc("Conference region.")
@@ -71,14 +67,12 @@ model ConferenceSubresourceUris {
 @doc("Conference model.")
 model Conference {
   @doc("The unique identifier for this conference.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472cf")
-  sid: string;
+  sid: uuid;
 
   @doc("The unique identifier for the account that created this conference.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The date, in RFC 2822 format, this conference was created.")
   @example("Mon, 24 Sept 2018 21:00:00 +0000")
@@ -114,28 +108,24 @@ model Conference {
 @doc("Conference participant model.")
 model ConferenceParticipant {
   @doc("The unique identifier for the account that created this conference.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The unique identifier for the Participant call connected to this conference.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ca")
-  call_sid: string;
+  call_sid: uuid;
 
   @doc("The unique identifier of the participant who is being coached.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472co")
-  call_sid_to_coach: string | null;
+  call_sid_to_coach: uuid | null;
 
   @doc("Whether the participant is coaching another call.")
   @example(false)
   coaching: boolean;
 
   @doc("The unique identifier for the conference this participant is in.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472cf")
-  conference_sid: string;
+  conference_sid: uuid;
 
   @doc("The date, in RFC 2822 format, this conference participant was created.")
   @example("Mon, 24 Sept 2018 21:00:00 +0000")
@@ -184,14 +174,12 @@ enum ConferenceStreamStatus {
 @doc("Conference stream model.")
 model ConferenceStream {
   @doc("The unique identifier for the account.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The unique identifier for the conference.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472cf")
-  conference_sid: string;
+  conference_sid: uuid;
 
   @doc("The date, in RFC 2822 GMT format, this stream was updated.")
   @example("Tue, 25 Sept 2018 20:00:00 +0000")
@@ -202,9 +190,8 @@ model ConferenceStream {
   name: string | null;
 
   @doc("The unique identifier for the stream.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472st")
-  sid: string;
+  sid: uuid;
 
   @doc("The status of the stream.")
   status: ConferenceStreamStatus;
@@ -217,17 +204,15 @@ model ConferenceStream {
 model ConferenceStreamSidPath {
   @doc("The unique identifier for the stream.")
   @example("b3877c40-da60-4998-90ad-b792e98472st")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 model ConferenceRecordingSidPath {
   @doc("The unique identifier for the recording.")
   @example("19e436af-5688-4307-b03b-bdb2b42b8142")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 @doc("Recording source for conference recordings.")
@@ -257,14 +242,12 @@ model ConferenceRecordingSubresourceUris {
 @doc("Conference recording model.")
 model ConferenceRecording {
   @doc("The unique identifier for the recording.")
-  @format("uuid")
   @example("19e436af-5688-4307-b03b-bdb2b42b8142")
-  sid: string;
+  sid: uuid;
 
   @doc("The unique identifier for the account that is associated with this recording.")
-  @format("uuid")
   @example("720796a0-8ee9-4350-83bd-2d07a3121f1e")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The version of the SignalWire API.")
   @example("2010-04-01")
@@ -275,9 +258,8 @@ model ConferenceRecording {
   call_sid: string | null;
 
   @doc("The unique identifier for the conference that is associated with this recording.")
-  @format("uuid")
   @example("43bb71ee-553f-4074-bb20-8e2747647cce")
-  conference_sid: string | null;
+  conference_sid: uuid | null;
 
   @doc("The number of channels in a recording (singular key). Returns '1' for mono or '2' for stereo.")
   @example("1")

--- a/specs/compatibility-api/conferences/models/requests.tsp
+++ b/specs/compatibility-api/conferences/models/requests.tsp
@@ -32,9 +32,8 @@ model UpdateConferenceParticipantRequest {
   Coaching?: boolean;
 
   @doc("The unique identifier of the participant who is being coached. Required when `Coaching` is true.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472co")
-  CallSidToCoach?: string;
+  CallSidToCoach?: uuid;
 
   @doc("Whether or not a participant is on hold.")
   @example(false)

--- a/specs/compatibility-api/cxml-scripts/models/core.tsp
+++ b/specs/compatibility-api/cxml-scripts/models/core.tsp
@@ -3,25 +3,22 @@ using TypeSpec.Http;
 model CxmlScriptsAccountSidPath {
   @doc("The unique identifier for the account this script is associated with.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model CxmlScriptSidPath {
   @doc("The unique identifier of the cXML script.")
   @example("5184b831-184f-4209-872d-ccdccc80f2f1")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 @doc("cXML Script model.")
 model CxmlScript {
   @doc("The unique identifier of the cXML script on SignalWire.")
-  @format("uuid")
   @example("5184b831-184f-4209-872d-ccdccc80f2f1")
-  sid: string;
+  sid: uuid;
 
   @doc("The date and time, in ISO 8601 format, the script was created.")
   @example("2019-11-26T20:00:00Z")
@@ -36,9 +33,8 @@ model CxmlScript {
   date_last_accessed: string | null;
 
   @doc("The unique identifier for the account this script is associated with.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("A friendly name given to the cXML script.")
   @example("Death Star IVR")

--- a/specs/compatibility-api/faxes/models/core.tsp
+++ b/specs/compatibility-api/faxes/models/core.tsp
@@ -3,25 +3,22 @@ using TypeSpec.Http;
 model FaxesAccountSidPath {
   @doc("The Project ID that uniquely identifies the Account.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model FaxSidPath {
   @doc("The Fax ID that uniquely identifies the Fax.")
   @example("b3877c40-da60-4998-90ad-b792e98472fx")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 model FaxSidPathForMedia {
   @doc("The Fax ID that uniquely identifies the Fax.")
   @example("b3877c40-da60-4998-90ad-b792e98472fx")
-  @format("uuid")
   @path
-  FaxSid: string;
+  FaxSid: uuid;
 }
 
 @doc("Fax direction.")

--- a/specs/compatibility-api/imported-phone-numbers/models/requests.tsp
+++ b/specs/compatibility-api/imported-phone-numbers/models/requests.tsp
@@ -3,9 +3,8 @@ using TypeSpec.Http;
 model ImportedPhoneNumbersAccountSidPath {
   @doc("The unique identifier for the account that is associated with this phone number.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 @doc("The type of phone number being imported.")

--- a/specs/compatibility-api/incoming-phone-numbers/models/core.tsp
+++ b/specs/compatibility-api/incoming-phone-numbers/models/core.tsp
@@ -3,17 +3,15 @@ using TypeSpec.Http;
 model IncomingPhoneNumbersAccountSidPath {
   @doc("The unique identifier for the account that is associated with this phone number.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model IncomingPhoneNumberSidPath {
   @doc("The unique identifier of the phone number.")
   @example("b3877c40-da60-4998-90ad-b792e98472pn")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 @doc("Address requirements.")
@@ -58,14 +56,12 @@ model IncomingPhoneNumberCapabilities {
 @doc("Incoming phone number model.")
 model IncomingPhoneNumber {
   @doc("The unique identifier for the account that is associated with this phone number.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ac")
-  account_id: string;
+  account_id: uuid;
 
   @doc("The unique identifier for the account that is associated with this phone number.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ac")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("Whether or not a registered address with SignalWire is required. Always 'none'.")
   address_requirements: AddressRequirements;

--- a/specs/compatibility-api/incoming-phone-numbers/models/requests.tsp
+++ b/specs/compatibility-api/incoming-phone-numbers/models/requests.tsp
@@ -16,9 +16,8 @@ model CreateIncomingPhoneNumberRequest {
   FriendlyName?: string;
 
   @doc("The unique identifier for the application associated with SMS handling on this phone number.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472sa")
-  SmsApplicationSid?: string;
+  SmsApplicationSid?: uuid;
 
   @doc("Whether the request to `SmsFallbackUrl` is a `GET` or a `POST`. Default is `POST`.")
   @example("POST")
@@ -49,9 +48,8 @@ model CreateIncomingPhoneNumberRequest {
   StatusCallbackMethod?: "GET" | "POST" = "POST";
 
   @doc("The unique identifier for the application associated with call handling on this phone number.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472va")
-  VoiceApplicationSid?: string;
+  VoiceApplicationSid?: uuid;
 
   @doc("Whether the request to VoiceFallbackUrl is a `GET` or a `POST`. Default is `POST`.")
   @example("POST")
@@ -79,14 +77,12 @@ model CreateIncomingPhoneNumberRequest {
 @doc("Request body for updating an incoming phone number.")
 model UpdateIncomingPhoneNumberRequest {
   @doc("The unique identifier for an account to which the number should be transferred. Must be within the same Space.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ac")
-  AccountSid?: string;
+  AccountSid?: uuid;
 
   @doc("The unique identifier of the address associated with E911 for this phone number. Not supported for toll-free numbers or certain providers.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ad")
-  EmergencyAddressSid?: string;
+  EmergencyAddressSid?: uuid;
 
   @doc("A friendly name for the phone number.")
   @minLength(1)
@@ -95,9 +91,8 @@ model UpdateIncomingPhoneNumberRequest {
   FriendlyName?: string;
 
   @doc("The unique identifier for the application associated with SMS handling on this phone number.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472sa")
-  SmsApplicationSid?: string;
+  SmsApplicationSid?: uuid;
 
   @doc("Whether the request to `SmsFallbackUrl` is a `GET` or a `POST`. Default is `POST`.")
   @example("POST")
@@ -127,9 +122,8 @@ model UpdateIncomingPhoneNumberRequest {
   StatusCallbackMethod?: "GET" | "POST" = "POST";
 
   @doc("The unique identifier for the application associated with call handling on this phone number.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472va")
-  VoiceApplicationSid?: string;
+  VoiceApplicationSid?: uuid;
 
   @doc("Whether the request to VoiceFallbackUrl is a `GET` or a `POST`. Default is `POST`.")
   @example("POST")

--- a/specs/compatibility-api/main.tsp
+++ b/specs/compatibility-api/main.tsp
@@ -3,6 +3,7 @@ import "@typespec/openapi";
 import "@typespec/openapi3";
 
 import "../_shared/auth.tsp";
+import "../_shared/types/main.tsp";
 import "./tags.tsp";
 import "./accounts/main.tsp";
 import "./applications/main.tsp";

--- a/specs/compatibility-api/messages/models/core.tsp
+++ b/specs/compatibility-api/messages/models/core.tsp
@@ -3,25 +3,22 @@ using TypeSpec.Http;
 model MessagesAccountSidPath {
   @doc("The unique identifier of the project that sent or received this message.")
   @example("ea108133-d6b3-407c-9536-9fad8a929a6a")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model MessageSidPath {
   @doc("A unique ID that identifies this specific message.")
   @example("0a059168-ead0-41af-9d1f-343dae832527")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 model MessageSidPathForMedia {
   @doc("A unique ID that identifies this specific message.")
   @example("0a059168-ead0-41af-9d1f-343dae832527")
-  @format("uuid")
   @path
-  MessageSid: string;
+  MessageSid: uuid;
 }
 
 @doc("Message status.")
@@ -53,9 +50,8 @@ model MessageSubresourceUris {
 @doc("Message model.")
 model Message {
   @doc("The unique identifier of the project that sent or received this message.")
-  @format("uuid")
   @example("ea108133-d6b3-407c-9536-9fad8a929a6a")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The version number of the SignalWire cXML REST API used to handle this message.")
   @example("2010-04-01")
@@ -109,9 +105,8 @@ model Message {
   price_unit: string;
 
   @doc("A unique ID that identifies this specific message.")
-  @format("uuid")
   @example("0a059168-ead0-41af-9d1f-343dae832527")
-  sid: string;
+  sid: uuid;
 
   @doc("Current status of the message.")
   status: MessageStatus;
@@ -121,9 +116,8 @@ model Message {
   to: string;
 
   @doc("If a number group was used when sending an outbound message, the number group's ID will be present, or null otherwise.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ms")
-  messaging_service_sid: string | null;
+  messaging_service_sid: uuid | null;
 
   @doc("The URI of this particular message.")
   @example("/api/laml/2010-04-01/Accounts/ea108133-d6b3-407c-9536-9fad8a929a6a/Messages/0a059168-ead0-41af-9d1f-343dae832527.json")
@@ -136,9 +130,8 @@ model Message {
 @doc("Message media model.")
 model MessageMedia {
   @doc("The unique identifier for the account.")
-  @format("uuid")
   @example("ea108133-d6b3-407c-9536-9fad8a929a6a")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The content type of the media.")
   @example("image/jpeg")
@@ -153,14 +146,12 @@ model MessageMedia {
   date_updated: string;
 
   @doc("The unique identifier for the message.")
-  @format("uuid")
   @example("0a059168-ead0-41af-9d1f-343dae832527")
-  parent_sid: string;
+  parent_sid: uuid;
 
   @doc("The unique identifier for the media.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472me")
-  sid: string;
+  sid: uuid;
 
   @doc("The URI for the media.")
   @example("/api/laml/2010-04-01/Accounts/ea108133-d6b3-407c-9536-9fad8a929a6a/Messages/0a059168-ead0-41af-9d1f-343dae832527/Media/b3877c40-da60-4998-90ad-b792e98472me.json")

--- a/specs/compatibility-api/messages/models/requests.tsp
+++ b/specs/compatibility-api/messages/models/requests.tsp
@@ -26,9 +26,8 @@ model CreateMessageRequest {
   SendAsMms?: boolean;
 
   @doc("The SID of a SignalWire cXML Application used to configure the message's status callback.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ap")
-  ApplicationSid?: string;
+  ApplicationSid?: uuid;
 
   @doc("The maximum price in USD acceptable for the message to be sent. Format: decimal with up to 4 decimal places.")
   @pattern("^\\d+\\.?\\d{0,4}$")
@@ -48,9 +47,8 @@ model CreateMessageRequest {
   ValidityPeriod?: int32 = 14400;
 
   @doc("The ID of a number group to use when sending the message. Either `From` or `MessagingServiceSid` must be provided.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ms")
-  MessagingServiceSid?: string;
+  MessagingServiceSid?: uuid;
 }
 
 @doc("Request body for updating (redacting) a message.")

--- a/specs/compatibility-api/queues/models/core.tsp
+++ b/specs/compatibility-api/queues/models/core.tsp
@@ -3,25 +3,22 @@ using TypeSpec.Http;
 model QueuesAccountSidPath {
   @doc("The unique identifier for the account this Queue is associated with.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model QueueSidPath {
   @doc("The unique identifier for the queue.")
   @example("b3877c40-da60-4998-90ad-b792e98472qu")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 model QueueSidPathForMembers {
   @doc("The unique identifier for the queue.")
   @example("b3877c40-da60-4998-90ad-b792e98472qu")
-  @format("uuid")
   @path
-  QueueSid: string;
+  QueueSid: uuid;
 }
 
 model QueueMemberCallSidPath {
@@ -35,13 +32,11 @@ model QueueMemberCallSidPath {
 model Queue {
   @doc("The unique identifier for the queue.")
   @example("b3877c40-da60-4998-90ad-b792e98472qu")
-  @format("uuid")
-  sid: string;
+  sid: uuid;
 
   @doc("The unique identifier for the account this Queue is associated with.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("A description that distinguishes a queue.")
   @example("Queue1")
@@ -82,18 +77,15 @@ model Queue {
 model QueueMember {
   @doc("The unique identifier for the call.")
   @example("b3877c40-da60-4998-90ad-b792e98472ca")
-  @format("uuid")
-  call_sid: string;
+  call_sid: uuid;
 
   @doc("The unique identifier for the account.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The unique identifier for the queue.")
   @example("b3877c40-da60-4998-90ad-b792e98472qu")
-  @format("uuid")
-  queue_sid: string;
+  queue_sid: uuid;
 
   @doc("The date and time, in RFC 2822 format, when the member was enqueued.")
   @example("Wed, 26 Sep 2018 18:00:00 +0000")

--- a/specs/compatibility-api/recordings/main.tsp
+++ b/specs/compatibility-api/recordings/main.tsp
@@ -41,15 +41,13 @@ namespace CompatibilityAPI.Recordings {
 
       @query
       @doc("Filter by recordings associated with a specific call.")
-      @format("uuid")
       @example("43bb71ee-553f-4074-bb20-8e2747647cce")
-      CallSid?: string,
+      CallSid?: uuid,
 
       @query
       @doc("Filter by recordings associated with a specific conference.")
-      @format("uuid")
       @example("b3877c40-da60-4998-90ad-b792e98472cf")
-      ConferenceSid?: string,
+      ConferenceSid?: uuid,
 
       @query
       @doc("The page number to retrieve (zero-indexed).")

--- a/specs/compatibility-api/recordings/models/core.tsp
+++ b/specs/compatibility-api/recordings/models/core.tsp
@@ -3,17 +3,15 @@ using TypeSpec.Http;
 model RecordingsAccountSidPath {
   @doc("The unique identifier for the account that is associated with this recording.")
   @example("720796a0-8ee9-4350-83bd-2d07a3121f1e")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model RecordingSidPath {
   @doc("The unique identifier for the recording.")
   @example("19e436af-5688-4307-b03b-bdb2b42b8142")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 @doc("Recording source.")
@@ -48,28 +46,24 @@ model RecordingSubresourceUris {
 @doc("Recording model.")
 model Recording {
   @doc("The unique identifier for the recording.")
-  @format("uuid")
   @example("19e436af-5688-4307-b03b-bdb2b42b8142")
-  sid: string;
+  sid: uuid;
 
   @doc("The unique identifier for the account that is associated with this recording.")
-  @format("uuid")
   @example("720796a0-8ee9-4350-83bd-2d07a3121f1e")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The version of the SignalWire API.")
   @example("2010-04-01")
   api_version: string;
 
   @doc("The unique identifier for the call that is associated with this recording. Null if this is a conference recording.")
-  @format("uuid")
   @example("43bb71ee-553f-4074-bb20-8e2747647cce")
-  call_sid: string | null;
+  call_sid: uuid | null;
 
   @doc("The unique identifier for the conference that is associated with this recording. Null if this is a call recording.")
-  @format("uuid")
   @example(null)
-  conference_sid: string | null;
+  conference_sid: uuid | null;
 
   @doc("The number of channels in a recording (singular key). Returns '1' for mono or '2' for stereo.")
   @example("1")

--- a/specs/compatibility-api/tokens/models/core.tsp
+++ b/specs/compatibility-api/tokens/models/core.tsp
@@ -3,25 +3,22 @@ using TypeSpec.Http;
 model TokensAccountSidPath {
   @doc("The unique identifier for the project you want to use to authenticate this request.")
   @example("b3877c40-da60-4998-90ad-b792e98472af")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model TokenIdPath {
   @doc("The unique identifier of the project API token.")
   @example("ea14556a-984f-11ee-b9d1-0242ac120002")
-  @format("uuid")
   @path
-  token_id: string;
+  token_id: uuid;
 }
 
 @doc("API Token model.")
 model Token {
   @doc("The unique identifier of the created API Token.")
-  @format("uuid")
   @example("ea14556a-984f-11ee-b9d1-0242ac120002")
-  id: string;
+  id: uuid;
 
   @doc("The name of the created API Token.")
   @example("John Doe's Token")

--- a/specs/compatibility-api/tokens/models/requests.tsp
+++ b/specs/compatibility-api/tokens/models/requests.tsp
@@ -13,9 +13,8 @@ model CreateTokenRequest {
   permissions: string[];
 
   @doc("The unique identifier of the subproject you would like to create a token for. Must belong to the parent project.")
-  @format("uuid")
   @example("9a7fc048-984f-11ee-b9d1-0242ac120002")
-  subproject_id?: string;
+  subproject_id?: uuid;
 }
 
 @doc("Request body for updating an API token.")

--- a/specs/compatibility-api/transcriptions/models/core.tsp
+++ b/specs/compatibility-api/transcriptions/models/core.tsp
@@ -3,39 +3,34 @@ using TypeSpec.Http;
 model TranscriptionsAccountSidPath {
   @doc("The unique identifier for the account that created this transcription.")
   @example("b3877c40-da60-4998-90ad-b792e98472ac")
-  @format("uuid")
   @path
-  AccountSid: string;
+  AccountSid: uuid;
 }
 
 model TranscriptionSidPath {
   @doc("The unique identifier for the transcription.")
   @example("b3877c40-da60-4998-90ad-b792e98472tr")
-  @format("uuid")
   @path
-  Sid: string;
+  Sid: uuid;
 }
 
 @doc("Transcription model.")
 model Transcription {
   @doc("The unique identifier for the transcription.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472tr")
-  sid: string;
+  sid: uuid;
 
   @doc("The unique identifier for the account that created this transcription.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472ac")
-  account_sid: string;
+  account_sid: uuid;
 
   @doc("The version of the SignalWire API.")
   @example("2010-04-01")
   api_version: string;
 
   @doc("The unique identifier for the recording that this transcription was created from.")
-  @format("uuid")
   @example("b3877c40-da60-4998-90ad-b792e98472re")
-  recording_sid: string;
+  recording_sid: uuid;
 
   @doc("The date, in RFC 2822 format, this transcription was created.")
   @example("Thu, 27 Sep 2018 02:00:00 +0000")

--- a/specs/signalwire-rest/calling-api/calls/main.tsp
+++ b/specs/signalwire-rest/calling-api/calls/main.tsp
@@ -5,6 +5,7 @@ import "../../../_shared/alias/token-permissions.tsp";
 import "./models/requests.tsp";
 import "./models/responses.tsp";
 import "./models/examples.tsp";
+import "../tags.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;

--- a/specs/signalwire-rest/datasphere-api/document/models/core.tsp
+++ b/specs/signalwire-rest/datasphere-api/document/models/core.tsp
@@ -5,23 +5,18 @@ using TypeSpec.Http;
 
 namespace SignalWireAPI.Datasphere;
 
-
-@format("uuid")
-@doc("Unique ID of a Document.")
-scalar docid extends string;
-
 model PathID {
   @doc("Unique ID of a Document.")
   @example("acaa5c49-be5e-4477-bce0-48f4b23b7720")
   @path
-  id: docid;
+  id: uuid;
 }
 
 model ChunkPathID {
   @doc("Unique ID of the parent Document.")
   @example("acaa5c49-be5e-4477-bce0-48f4b23b7720")
   @path
-  documentId: docid;
+  documentId: uuid;
 
   @doc("Unique ID of a Chunk.")
   @example("d369a402-7b43-4512-8735-9d5e1f387814")
@@ -33,13 +28,13 @@ model DocumentPathID {
   @doc("Unique ID of the Document.")
   @example("acaa5c49-be5e-4477-bce0-48f4b23b7720")
   @path
-  documentId: docid;
+  documentId: uuid;
 }
 
 model Document {
   @doc("Unique ID of the Document.")
   @example("acaa5c49-be5e-4477-bce0-48f4b23b7720")
-  id: docid;
+  id: uuid;
 
   @doc("Name of the Document.")
   @example("player_list.pdf")
@@ -97,5 +92,5 @@ model Chunk {
 
   @doc("Unique ID of the Document.")
   @example("acaa5c49-be5e-4477-bce0-48f4b23b7720")
-  document_id: docid;
+  document_id: uuid;
 }

--- a/specs/signalwire-rest/datasphere-api/document/models/requests.tsp
+++ b/specs/signalwire-rest/datasphere-api/document/models/requests.tsp
@@ -14,7 +14,7 @@ model DocumentSearchRequest {
 
   @doc("Unique ID of a Document.")
   @example("acaa5c49-be5e-4477-bce0-48f4b23b7720")
-  document_id?: docid;
+  document_id?: uuid;
 
   @doc("Search term.")
   @example("Most paid athlete")

--- a/specs/signalwire-rest/fabric-api/_shared/fabric-address/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/_shared/fabric-address/models/core.tsp
@@ -8,7 +8,6 @@ using TypeSpec.Http;
 model FabricAddressID {
   @doc("Unique ID of a FabricAddress.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -16,7 +15,6 @@ model FabricAddressID {
 model FabricAddress {
   @doc("Unique ID of the Fabric Address.")
   @example("691af061-cd86-4893-a605-173f47afc4c2")
-  @format("uuid")
   id: uuid;
 
   @doc("Name of the Fabric Address.")

--- a/specs/signalwire-rest/fabric-api/ai-agent/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/ai-agent/addresses/models/core.tsp
@@ -8,7 +8,6 @@ using TypeSpec.OpenAPI;
 model AIAgentIDPath {
   @doc("Unique ID of a AI Agent.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   ai_agent_id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/ai-agent/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/ai-agent/models/responses.tsp
@@ -5,12 +5,10 @@ import "../../_shared/fabric-address";
 model AIAgentResponse {
   @doc("Unique ID of the AIAgent.")
   @example("a87db7ed-8ebe-42e4-829f-8ba5a4152f54")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("99151cf8-9548-4860-ba70-a8de824f3312")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the AIAgent Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/call-flows/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/call-flows/addresses/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model CallFlowAddressPathID {
   @doc("The unique identifier of the Call Flow.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/call-flows/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/call-flows/models/core.tsp
@@ -6,7 +6,6 @@ using TypeSpec.Http;
 model CallFlowPathID {
   @doc("Unique ID of a Call Flow.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -14,7 +13,6 @@ model CallFlowPathID {
 model CallFlow {
   @doc("Unique ID of a Call Flow.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The name of the Call Flow")

--- a/specs/signalwire-rest/fabric-api/call-flows/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/call-flows/models/responses.tsp
@@ -5,12 +5,10 @@ import "../../_shared/const.tsp";
 model CallFlowResponse {
   @doc("Unique ID of the Call Flow.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the Call Flow Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/call-flows/versions/models/requests.tsp
+++ b/specs/signalwire-rest/fabric-api/call-flows/versions/models/requests.tsp
@@ -20,6 +20,5 @@ model CallFlowVersionDeployByDocumentVersion {
 model CallFlowVersionDeployByVersionId {
   @doc("Any call flow version ID for this call flow.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   call_flow_version_id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/call-flows/versions/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/call-flows/versions/models/responses.tsp
@@ -4,7 +4,6 @@ import "../../../_shared/const.tsp";
 model CallFlowVersion {
   @doc("The unique identifier of the version.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The version number.")
@@ -38,7 +37,6 @@ model CallFlowVersionListResponse {
 model CallFlowVersionDeployResponse {
   @doc("The unique identifier of the deployed Call Flow Version.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("The creation timestamp.")

--- a/specs/signalwire-rest/fabric-api/conference-rooms/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/conference-rooms/addresses/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model ConferenceRoomAddressPathID {
   @doc("The unique identifier of the Conference Room.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/conference-rooms/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/conference-rooms/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model ConferenceRoomPathID {
   @doc("Unique ID of a Conference Room.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -13,7 +12,6 @@ model ConferenceRoomPathID {
 model ConferenceRoom {
   @doc("The unique id of the Conference Room")
   @example("1bd571e4-5ea4-4a70-a3c8-2bab5d20e754")
-  @format("uuid")
   id: uuid;
 
   @doc("The name of the Conference Room")

--- a/specs/signalwire-rest/fabric-api/conference-rooms/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/conference-rooms/models/responses.tsp
@@ -13,12 +13,10 @@ model ConferenceRoomListResponse {
 model ConferenceRoomResponse {
   @doc("Unique ID of the Conference Room.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the Conference Room Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/cxml-applications/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/cxml-applications/addresses/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model CxmlApplicationAddressPathID {
   @doc("The unique identifier of the cXML Application.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
-  id: string;
+  id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/cxml-applications/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/cxml-applications/models/responses.tsp
@@ -5,12 +5,10 @@ import "../../_shared/const.tsp";
 model CxmlApplicationResponse {
   @doc("Unique ID of the cXML Application.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the cXML Application Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/cxml-scripts/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/cxml-scripts/addresses/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model CXMLScriptAddressPathID {
   @doc("The unique identifier of the cXML Script.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
-  id: string;
+  id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/cxml-scripts/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/cxml-scripts/models/responses.tsp
@@ -5,12 +5,10 @@ import "../../_shared/const.tsp";
 model CXMLScriptResponse {
   @doc("Unique ID of the cXML Script.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the cXML Script Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/cxml-webhooks/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/cxml-webhooks/addresses/models/core.tsp
@@ -8,7 +8,6 @@ using TypeSpec.OpenAPI;
 model CXMLWebhookIDPath {
   @doc("Unique ID of a CXML Webhook.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   cxml_webhook_id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/cxml-webhooks/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/cxml-webhooks/models/responses.tsp
@@ -4,12 +4,10 @@ import "../../_shared/const.tsp";
 model CXMLWebhookResponse {
   @doc("Unique ID of the CXMLWebhook.")
   @example("a87db7ed-8ebe-42e4-829f-8ba5a4152f54")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("99151cf8-9548-4860-ba70-a8de824f3312")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the CXMLWebhook Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/dialogflow-agents/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/dialogflow-agents/addresses/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model DialogflowAgentAddressPathID {
   @doc("The unique identifier of the Dialogflow Agent Address.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
-  id: string;
+  id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/dialogflow-agents/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/dialogflow-agents/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model DialogflowAgentPathID {
   @doc("Unique ID of a Dialogflow Agent.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -13,7 +12,6 @@ model DialogflowAgentPathID {
 model DialogflowAgent {
   @doc("Unique ID of a Dialogflow Agent.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("Whether to enable the 'say' feature")
@@ -34,7 +32,6 @@ model DialogflowAgent {
 
   @doc("Dialogflow reference ID")
   @example("12345678-1234-1234-1234-1234567890ab")
-  @format("uuid")
   dialogflow_reference_id?: uuid;
 
   @doc("Dialogflow reference name")

--- a/specs/signalwire-rest/fabric-api/dialogflow-agents/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/dialogflow-agents/models/responses.tsp
@@ -5,12 +5,10 @@ import "../../_shared/const.tsp";
 model DialogflowAgentResponse {
   @doc("Unique ID of the Dialogflow Agent.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the Dialogflow Agent Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/domain-applications/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/domain-applications/models/core.tsp
@@ -6,7 +6,6 @@ using TypeSpec.Http;
 model FabricDomainApplicationPathID {
   @doc("The unique identifier of the Resource.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/domain-applications/models/requests.tsp
+++ b/specs/signalwire-rest/fabric-api/domain-applications/models/requests.tsp
@@ -1,6 +1,5 @@
 model DomainApplicationAssignRequest {
   @doc("The id of the domain application you wish to assign a resource to.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   domain_application_id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/freeswitch-connectors/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/freeswitch-connectors/addresses/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model FreeswitchConnectorAddressPathID {
   @doc("The unique identifier of the FreeSWITCH Connector.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/freeswitch-connectors/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/freeswitch-connectors/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model FreeswitchConnectorPathID {
   @doc("Unique ID of a FreeSWITCH Connector.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -13,7 +12,6 @@ model FreeswitchConnectorPathID {
 model FreeswitchConnector {
   @doc("Unique ID of a FreeSWITCH Connector.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("Name of the FreeSWITCH Connector")

--- a/specs/signalwire-rest/fabric-api/freeswitch-connectors/models/requests.tsp
+++ b/specs/signalwire-rest/fabric-api/freeswitch-connectors/models/requests.tsp
@@ -7,7 +7,6 @@ model FreeswitchConnectorCreateRequest {
 
   @doc("FreeSWITCH token")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   token: uuid;
 }
 

--- a/specs/signalwire-rest/fabric-api/freeswitch-connectors/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/freeswitch-connectors/models/responses.tsp
@@ -5,12 +5,10 @@ import "../../_shared/const.tsp";
 model FreeswitchConnectorResponse {
   @doc("Unique ID of the FreeSWITCH Connector.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the FreeSWITCH Connector Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/phone-routes/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/phone-routes/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model PhoneRoutePathID {
   @doc("The unique identifier of the Resource.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/phone-routes/models/requests.tsp
+++ b/specs/signalwire-rest/fabric-api/phone-routes/models/requests.tsp
@@ -3,7 +3,6 @@ import "../../_shared/enums.tsp";
 model PhoneRouteAssignRequest {
   @doc("The id of the phone route.")
   @example("691af061-cd86-4893-a605-173f47afc4c2")
-  @format("uuid")
   phone_route_id: uuid;
 
   @doc("Indicates if the resource should be assigned to a `calling` or `messaging` handler.")

--- a/specs/signalwire-rest/fabric-api/relay-applications/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/relay-applications/addresses/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model RelayApplicationAddressPathID {
   @doc("The unique identifier of the Relay Application.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
-  id: string;
+  id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/relay-applications/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/relay-applications/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model RelayApplicationPathID {
   @doc("Unique ID of a Relay Application.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -13,7 +12,6 @@ model RelayApplicationPathID {
 model RelayApplication {
   @doc("Unique ID of a Relay Application.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("Name of the Relay Application")

--- a/specs/signalwire-rest/fabric-api/relay-applications/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/relay-applications/models/responses.tsp
@@ -5,12 +5,10 @@ import "../../_shared/const.tsp";
 model RelayApplicationResponse {
   @doc("Unique ID of the Relay Application.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the Relay Application Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/resources/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/resources/addresses/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model ResourceAddressPathID {
   @doc("The unique identifier of the Resource.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/resources/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/resources/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model ResourcePathID {
   @doc("Unique ID of a Resource.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/resources/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/resources/models/responses.tsp
@@ -26,12 +26,10 @@ const RESPONSE_TYPE_DESC = "The type of Resource";
 model ResourceResponseBase {
   @doc("Unique ID of the Resource.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the Resource")

--- a/specs/signalwire-rest/fabric-api/sip-endpoints/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/sip-endpoints/addresses/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model SipEndpointAddressPathID {
   @doc("The unique identifier of the SIP Endpoint.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/sip-endpoints/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/sip-endpoints/models/core.tsp
@@ -15,7 +15,6 @@ const callHandlerDescription = """
 model FabricSipEndpointPathID {
   @doc("Unique ID of a SIP Endpoint.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -23,7 +22,6 @@ model FabricSipEndpointPathID {
 model FabricSipEndpoint {
   @doc("The id of the Sip Endpoint")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("The username of the Sip Endpoint")

--- a/specs/signalwire-rest/fabric-api/sip-endpoints/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/sip-endpoints/models/responses.tsp
@@ -5,12 +5,10 @@ import "../../_shared/enums.tsp";
 model FabricSipEndpointResponse {
   @doc("Unique ID of the SIP Endpoint.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the SIP Endpoint Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/sip-endpoints/resource/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/sip-endpoints/resource/models/core.tsp
@@ -6,7 +6,6 @@ using TypeSpec.Http;
 model ResourceSipEndpointPathID {
   @doc("The unique identifier of the Resource.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -14,7 +13,6 @@ model ResourceSipEndpointPathID {
 model ResourceSipEndpoint {
   @doc("The unique identifier of the SIP endpoint.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The name for the SIP endpoint.")

--- a/specs/signalwire-rest/fabric-api/sip-endpoints/resource/models/requests.tsp
+++ b/specs/signalwire-rest/fabric-api/sip-endpoints/resource/models/requests.tsp
@@ -2,6 +2,5 @@
 model ResourceSipEndpointAssignRequest {
   @doc("The unique identifier of the SIP endpoint.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   sip_endpoint_id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/sip-endpoints/resource/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/sip-endpoints/resource/models/responses.tsp
@@ -4,7 +4,6 @@ import "../../../_shared/enums.tsp";
 model ResourceSipEndpointResponse {
   @doc("The unique identifier of the SIP endpoint.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The name for the SIP endpoint.")

--- a/specs/signalwire-rest/fabric-api/sip_gateways/addresses/models/requests.tsp
+++ b/specs/signalwire-rest/fabric-api/sip_gateways/addresses/models/requests.tsp
@@ -6,7 +6,6 @@ using TypeSpec.Http;
 model SipGatewayAddressRequest {
   @doc("The unique identifier of the SIP Gateway.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/sip_gateways/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/sip_gateways/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model SipGatewayID {
   @doc("Unique ID of a SIP Gateway.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/sip_gateways/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/sip_gateways/models/responses.tsp
@@ -11,13 +11,11 @@ using TypeSpec.OpenAPI;
 model SipGatewayResponse {
   @doc("Unique ID of the resource.")
   @example("0823a606-0aff-4c90-9eba-f88ba118fe05")
-  @format("uuid")
-  id: string;
+  id: uuid;
 
   @doc("Project ID associated with the resource.")
   @example("bc949800-7b40-43cf-8438-a85facfcbdd1")
-  @format("uuid")
-  project_id: string;
+  project_id: uuid;
 
   @doc("Display name of the SIP Gateway.")
   @example("My SIP Gateway")
@@ -42,8 +40,7 @@ model SipGatewayResponse {
 model SipGateway {
   @doc("Unique ID of the SIP Gateway.")
   @example("cce59cad-104d-4c28-ada4-98cfd102ae09")
-  @format("uuid")
-  id: string;
+  id: uuid;
 
   @doc("The URI for the SIP Gateway.")
   @example("user3@domain.com")

--- a/specs/signalwire-rest/fabric-api/subscribers/invite-tokens/models/requests.tsp
+++ b/specs/signalwire-rest/fabric-api/subscribers/invite-tokens/models/requests.tsp
@@ -1,7 +1,6 @@
 model SubscriberInviteTokenCreateRequest {
   @doc("Unique ID of a Subscriber Address")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   address_id: uuid;
 
   @doc("A unixtime (the number of seconds since 1970-01-01 00:00:00) at which the token should no longer be valid. Defaults to 'two hours from now'")

--- a/specs/signalwire-rest/fabric-api/subscribers/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/subscribers/models/core.tsp
@@ -6,7 +6,6 @@ using Types;
 model SubscriberPathID {
   @doc("Unique ID of a Subscriber.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -14,7 +13,6 @@ model SubscriberPathID {
 model Subscriber {
   @doc("Unique ID of the Subscriber.")
   @example("d369a402-7b43-4512-8735-9d5e1f387814")
-  @format("uuid")
   id: uuid;
 
   @doc("Email of the Subscriber.")

--- a/specs/signalwire-rest/fabric-api/subscribers/subscriber-addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/subscribers/subscriber-addresses/models/core.tsp
@@ -6,7 +6,6 @@ using TypeSpec.Http;
 model SubscriberAddressID {
   @doc("Unique ID of a Subscriber Address.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/subscribers/subscriber-sip-endpoint/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/subscribers/subscriber-sip-endpoint/models/core.tsp
@@ -6,7 +6,6 @@ using TypeSpec.Http;
 model FabricSubscriberID {
   @doc("Unique ID of a Fabric Subscriber.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   fabric_subscriber_id: uuid;
 }
@@ -14,7 +13,6 @@ model FabricSubscriberID {
 model SIPEndpointID {
   @doc("Unique ID of a Sip Endpoint.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/subscribers/subscriber-tokens/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/subscribers/subscriber-tokens/models/core.tsp
@@ -3,7 +3,6 @@ import "../../../../types";
 model SubscriberToken {
   @doc("The ID of the subscriber that the token is associated with.")
   @example("32d94154-9297-418c-9a85-4a69e0c67c30")
-  @format("uuid")
   subscriber_id: uuid;
 
   @doc("The token that is associated with the subscriber.")

--- a/specs/signalwire-rest/fabric-api/subscribers/subscriber-tokens/models/requests.tsp
+++ b/specs/signalwire-rest/fabric-api/subscribers/subscriber-tokens/models/requests.tsp
@@ -11,7 +11,6 @@ model SubscriberTokenRequest {
 
   @doc("The ID of the application that the token is associated with.")
   @example("123e4567-e89b-12d3-a456-426614174000")
-  @format("uuid")
   application_id?: uuid;
 
   @doc("Set or update the subscriber's password. Omit this field or pass an empty string if you don't want to update the password.")

--- a/specs/signalwire-rest/fabric-api/swml-scripts/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/swml-scripts/addresses/models/core.tsp
@@ -5,7 +5,6 @@ using TypeSpec.Http;
 model SWMLScriptAddressPathID {
   @doc("The unique identifier of the SWML Script.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
-  id: string;
+  id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/swml-scripts/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/swml-scripts/models/responses.tsp
@@ -5,12 +5,10 @@ import "../../_shared/const.tsp";
 model SwmlScriptResponse {
   @doc("Unique ID of the SWML Script.")
   @example("993ed018-9e79-4e50-b97b-984bd5534095")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("1313fe58-5e14-4c11-bbe7-6fdfa11fe780")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the SWML Script Fabric Resource")

--- a/specs/signalwire-rest/fabric-api/swml-webhook/addresses/models/core.tsp
+++ b/specs/signalwire-rest/fabric-api/swml-webhook/addresses/models/core.tsp
@@ -8,7 +8,6 @@ using TypeSpec.OpenAPI;
 model SWMLWebhookIDPath {
   @doc("Unique ID of a SWML Webhook.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   swml_webhook_id: uuid;
 }

--- a/specs/signalwire-rest/fabric-api/swml-webhook/models/responses.tsp
+++ b/specs/signalwire-rest/fabric-api/swml-webhook/models/responses.tsp
@@ -4,12 +4,10 @@ import "../../_shared/const.tsp";
 model SWMLWebhookResponse {
   @doc("Unique ID of the SWML Webhook.")
   @example("a87db7ed-8ebe-42e4-829f-8ba5a4152f54")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the Project.")
   @example("99151cf8-9548-4860-ba70-a8de824f3312")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Display name of the SWML Webhook Fabric Resource")

--- a/specs/signalwire-rest/fax-api/logs/models/core.tsp
+++ b/specs/signalwire-rest/fax-api/logs/models/core.tsp
@@ -8,7 +8,6 @@ namespace SignalWireAPI.Fax;
 
 model LogPathID {
   @doc("Unique ID of the log")
-  @format("uuid")
   @path
   @example("b7182dc2-00f3-40e4-a5ce-20f164b329df")
   id: uuid;
@@ -26,7 +25,6 @@ model ChargeDetail {
 
 model FaxLog {
   @doc("A unique identifier for the log")
-  @format("uuid")
   @example("b7182dc2-00f3-40e4-a5ce-20f164b329df")
   id: uuid;
 

--- a/specs/signalwire-rest/logs-api/conferences/models/core.tsp
+++ b/specs/signalwire-rest/logs-api/conferences/models/core.tsp
@@ -4,8 +4,7 @@ namespace SignalWireAPI.Logs;
 model Conference {
   @doc("Unique identifier for the conference.")
   @example("b9028451-b1d3-4690-b5d3-37b19d25f573")
-  @format("uuid")
-  id: string;
+  id: uuid;
 
   @doc("Creation timestamp.")
   @example(utcDateTime.fromISO("2025-03-11T01:49:49.630Z"))

--- a/specs/signalwire-rest/message-api/logs/models/core.tsp
+++ b/specs/signalwire-rest/message-api/logs/models/core.tsp
@@ -9,7 +9,6 @@ namespace SignalWireAPI.Message;
 
 @doc("Unique ID of the log.")
 model LogPathID {
-  @format("uuid")
   @doc("Unique ID of the log.")
   @path
   id: uuid;
@@ -28,7 +27,6 @@ model ChargeDetail {
 
 @doc("Message log entry with all activity details")
 model MessageLog {
-  @format("uuid")
   @doc("A unique identifier for the log.")
   id: uuid;
 

--- a/specs/signalwire-rest/message-api/messages/models/core.tsp
+++ b/specs/signalwire-rest/message-api/messages/models/core.tsp
@@ -9,10 +9,9 @@ namespace SignalWireAPI.Message;
 @doc("Path parameter identifying the target message by its segment ID.")
 model MessagePathID {
   @path
-  @format("uuid")
   @doc("The message segment ID — the same ID returned by the create endpoint and shown in `/api/messaging/logs`.")
   @example("c2d3e4f5-a6b7-8901-cdef-234567890abc")
-  message_id: string;
+  message_id: uuid;
 }
 
 @doc("Delivery state of a message.")
@@ -59,7 +58,6 @@ enum MessageKind {
 
 @doc("A message record. Returned by the create and update endpoints.")
 model Message {
-  @format("uuid")
   @doc("The unique ID of the message. This is the `MessageSegment` ID, consistent with the dashboard and the `/api/messaging/logs` endpoint.")
   @example("c2d3e4f5-a6b7-8901-cdef-234567890abc")
   id: uuid;
@@ -108,7 +106,6 @@ model Message {
   @example(UTC_TIME_EXAMPLE)
   created_at: utcDateTime;
 
-  @format("uuid")
   @doc("The ID of the project the message belongs to.")
   @example("a1b2c3d4-e5f6-7890-abcd-ef1234567890")
   project_id: uuid;

--- a/specs/signalwire-rest/project-api/tokens/main.tsp
+++ b/specs/signalwire-rest/project-api/tokens/main.tsp
@@ -55,10 +55,9 @@ namespace SignalWireAPI.Project.Tokens {
     @patch(#{ implicitOptionality: true })
     update(
       @path
-      @format("uuid")
       @doc("The unique identifier of the token to update.")
       @example("ea14556a-984f-11ee-b9d1-0242ac120002")
-      token_id: string,
+      token_id: uuid,
 
       ...UpdateTokenRequest,
     ):
@@ -81,10 +80,9 @@ namespace SignalWireAPI.Project.Tokens {
     @delete
     delete(
       @path
-      @format("uuid")
       @doc("The unique identifier of the token that you want to delete.")
       @example("ea14556a-984f-11ee-b9d1-0242ac120002")
-      token_id: string,
+      token_id: uuid,
     ):
       | {
           @statusCode statusCode: 204;

--- a/specs/signalwire-rest/project-api/tokens/models/core.tsp
+++ b/specs/signalwire-rest/project-api/tokens/models/core.tsp
@@ -19,8 +19,7 @@ enum TokenPermission {
 model TokenResponse {
   @doc("The ID of the created API Token.")
   @example("ea14556a-984f-11ee-b9d1-0242ac120002")
-  @format("uuid")
-  id: string;
+  id: uuid;
 
   @doc("The name of the created API Token.")
   @example("John Doe's Token")

--- a/specs/signalwire-rest/project-api/tokens/models/requests.tsp
+++ b/specs/signalwire-rest/project-api/tokens/models/requests.tsp
@@ -20,8 +20,7 @@ model CreateTokenRequest {
 
   @doc("The unique identifier of the subproject you would like to create a token for. The subproject passed must be a child of the project used to authenticate the request.")
   @example("9a7fc048-984f-11ee-b9d1-0242ac120002")
-  @format("uuid")
-  subproject_id?: string;
+  subproject_id?: uuid;
 }
 
 @doc("Request body for updating an API Token.")

--- a/specs/signalwire-rest/relay-rest/addresses/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/addresses/models/core.tsp
@@ -6,7 +6,6 @@ using Types;
 model AddressPathID {
   @doc("Unique ID of the address.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -29,7 +28,6 @@ enum AddressType {
 model Address {
   @doc("The unique identifier of the Address on SignalWire.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("A friendly name given to the address to help distinguish and search for different addresses within your project.")

--- a/specs/signalwire-rest/relay-rest/campaign-registry/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/campaign-registry/models/core.tsp
@@ -6,7 +6,6 @@ using Types;
 model BrandPathID {
   @doc("Unique ID of the brand.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -14,7 +13,6 @@ model BrandPathID {
 model CampaignPathID {
   @doc("Unique ID of the campaign.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -22,7 +20,6 @@ model CampaignPathID {
 model AssignedNumberPathID {
   @doc("Unique ID of the assigned number.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -30,7 +27,6 @@ model AssignedNumberPathID {
 model OrderPathID {
   @doc("Unique ID of the order.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -68,7 +64,6 @@ enum AssignmentState {
 model Brand {
   @doc("The unique identifier of the brand.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The current state of the brand.")
@@ -137,7 +132,6 @@ model Brand {
 model Campaign {
   @doc("The unique identifier of the campaign.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("A name for the campaign.")
@@ -255,7 +249,6 @@ model Campaign {
 @doc("Phone number details in an assignment.")
 model AssignedPhoneNumber {
   @doc("The unique identifier of the phone number.")
-  @format("uuid")
   id?: uuid;
 
   @doc("The name of the phone number.")
@@ -275,7 +268,6 @@ model AssignedPhoneNumber {
 model AssignedNumber {
   @doc("The unique identifier of the assignment.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The current state of the assignment.")
@@ -284,7 +276,6 @@ model AssignedNumber {
 
   @doc("The campaign ID associated with the number.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   campaign_id?: uuid;
 
   @doc("The phone number details.")
@@ -301,7 +292,6 @@ model AssignedNumber {
 model Order {
   @doc("The unique identifier of the order.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The current state of the order.")

--- a/specs/signalwire-rest/relay-rest/campaign-registry/models/requests.tsp
+++ b/specs/signalwire-rest/relay-rest/campaign-registry/models/requests.tsp
@@ -146,7 +146,6 @@ model CreateManagedCampaignRequest {
 
   @doc("The ID of the brand to associate with this campaign.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   brand_id: uuid;
 
   @doc("An SMS Use Case category for the campaign.")
@@ -269,7 +268,6 @@ model CreatePartnerCampaignRequest {
 
   @doc("The ID of the brand to associate with this campaign. Must be a CSP/partner brand.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   brand_id: uuid;
 
   @doc("The approved Campaign ID from TCR. Required for CSP/self-registered campaigns.")
@@ -306,7 +304,6 @@ model CreateOrderRequest {
 model AssignNumberRequest {
   @doc("The phone number ID to assign.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   phone_number_id: uuid;
 }
 

--- a/specs/signalwire-rest/relay-rest/domain-applications/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/domain-applications/models/core.tsp
@@ -6,7 +6,6 @@ using Types;
 model DomainApplicationPathID {
   @doc("Unique ID of the domain application.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -47,7 +46,6 @@ enum DomainAppCallHandler {
 model DomainApplication {
   @doc("The unique identifier of the domain application on SignalWire.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("A string representation of the type of object this record is.")
@@ -81,7 +79,6 @@ model DomainApplication {
 
   @doc("The unique identifier of the calling handler resource.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   calling_handler_resource_id: uuid | null;
 
   @doc("A string representing the Relay topic to forward incoming calls to.")
@@ -128,7 +125,6 @@ model DomainApplication {
 
   @doc("A string representing the ID of the Video Room to forward incoming calls to.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   call_video_room_id: uuid | null;
 
   @doc("A string representing the URL of the Relay script to execute when a call is received.")

--- a/specs/signalwire-rest/relay-rest/domain-applications/models/requests.tsp
+++ b/specs/signalwire-rest/relay-rest/domain-applications/models/requests.tsp
@@ -80,7 +80,6 @@ model CreateDomainApplicationRequest {
 
   @doc("A string representing the ID of the Video Room to forward incoming calls to. Required when call_handler is video_room.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   call_video_room_id?: uuid;
 
   @doc("A string representing the URL of the Relay script to execute when a call is received. Required when call_handler is relay_script.")
@@ -89,17 +88,14 @@ model CreateDomainApplicationRequest {
 
   @doc("A string representing the ID of the Dialogflow Agent to forward incoming calls to. Required when call_handler is dialogflow.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   call_dialogflow_agent_id?: uuid;
 
   @doc("A string representing the ID of the AI Agent to forward incoming calls to. Required when call_handler is ai_agent.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   call_ai_agent_id?: uuid;
 
   @doc("A string representing the ID of the Call Flow to forward incoming calls to. Required when call_handler is call_flow.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   call_flow_id?: uuid;
 
   @doc("A string representing the version of your Call Flow you'd like to use.")
@@ -188,7 +184,6 @@ model UpdateDomainApplicationRequest {
 
   @doc("A string representing the ID of the Video Room to forward incoming calls to.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   call_video_room_id?: uuid;
 
   @doc("A string representing the URL of the Relay script to execute when a call is received.")
@@ -197,17 +192,14 @@ model UpdateDomainApplicationRequest {
 
   @doc("A string representing the ID of the Dialogflow Agent to forward incoming calls to.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   call_dialogflow_agent_id?: uuid;
 
   @doc("A string representing the ID of the AI Agent to forward incoming calls to.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   call_ai_agent_id?: uuid;
 
   @doc("A string representing the ID of the Call Flow to forward incoming calls to.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   call_flow_id?: uuid;
 
   @doc("A string representing the version of your Call Flow you'd like to use.")

--- a/specs/signalwire-rest/relay-rest/mfa/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/mfa/models/core.tsp
@@ -6,7 +6,6 @@ using Types;
 model MfaRequestIdPath {
   @doc("The MFA request ID.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   mfa_request_id: uuid;
 }
@@ -46,7 +45,6 @@ model MfaRequest {
 model MfaResponse {
   @doc("The MFA request ID. Save this for verification.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("Whether the request was successfully queued.")

--- a/specs/signalwire-rest/relay-rest/number-groups/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/number-groups/models/core.tsp
@@ -6,7 +6,6 @@ using Types;
 model NumberGroupPathID {
   @doc("Unique ID of the number group.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -14,7 +13,6 @@ model NumberGroupPathID {
 model NumberGroupIdPath {
   @doc("Unique ID of the number group.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   NumberGroupId: uuid;
 }
@@ -22,7 +20,6 @@ model NumberGroupIdPath {
 model NumberGroupMembershipPathID {
   @doc("Unique ID of the number group membership.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -31,7 +28,6 @@ model NumberGroupMembershipPathID {
 model NumberGroup {
   @doc("The unique identifier of the Number Group on SignalWire. This can be used to update or delete the group programmatically.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The name given to the number group. Helps to distinguish different groups within your project.")
@@ -50,7 +46,6 @@ model NumberGroup {
 @doc("Phone number representation within a membership.")
 model MembershipPhoneNumber {
   @doc("The unique identifier of the phone number.")
-  @format("uuid")
   id?: uuid;
 
   @doc("The name given to the phone number.")
@@ -70,12 +65,10 @@ model MembershipPhoneNumber {
 model NumberGroupMembership {
   @doc("The unique identifier of the Number Group Membership on SignalWire. This can be used to delete the membership programmatically.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The unique identifier of the Number Group this membership is associated with.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   number_group_id: uuid;
 
   @doc("A representation of the phone number this membership is associated with.")

--- a/specs/signalwire-rest/relay-rest/number-groups/models/requests.tsp
+++ b/specs/signalwire-rest/relay-rest/number-groups/models/requests.tsp
@@ -28,6 +28,5 @@ model UpdateNumberGroupRequest {
 model AddNumberGroupMembershipRequest {
   @doc("The phone number ID to add to the group.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   phone_number_id: uuid;
 }

--- a/specs/signalwire-rest/relay-rest/phone-numbers/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/phone-numbers/models/core.tsp
@@ -76,7 +76,6 @@ enum PhoneNumberCallHandlerRequest {
 model PhoneNumberPathID {
   @doc("Unique ID of the phone number.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -92,7 +91,6 @@ model E164NumberPath {
 model PhoneNumber {
   @doc("The unique identifier of the phone number.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The phone number in E.164 format.")
@@ -111,7 +109,6 @@ model PhoneNumber {
   number_type: PhoneNumberType;
 
   @doc("The E911 address ID associated with this phone number.")
-  @format("uuid")
   e911_address_id: uuid | null;
 
   @doc("The date the number was added to your project.")
@@ -129,7 +126,6 @@ model PhoneNumber {
 
   @doc("The unique identifier of the calling handler resource.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   calling_handler_resource_id: uuid | null;
 
   @doc("How do you want to receive the incoming call.")
@@ -191,7 +187,6 @@ model PhoneNumber {
   call_relay_connector_id: string | null;
 
   @doc("The ID of the Relay SIP Endpoint to send this call to when using the relay_sip_endpoint call handler.")
-  @format("uuid")
   call_sip_endpoint_id: uuid | null;
 
   @doc("The name of the Verto Relay Endpoint to send this call to when using the relay_verto_endpoint call handler.")
@@ -199,7 +194,6 @@ model PhoneNumber {
 
   @doc("The ID of the Video Room to send this call to when using the video_room call handler.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   call_video_room_id: uuid | null;
 
   @doc("What type of handler you want to run on inbound messages.")
@@ -208,7 +202,6 @@ model PhoneNumber {
 
   @doc("The unique identifier of the messaging handler resource.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   messaging_handler_resource_id: uuid | null;
 
   @doc("The URL to make a request to when using the laml_webhooks message handler.")

--- a/specs/signalwire-rest/relay-rest/phone-numbers/models/requests.tsp
+++ b/specs/signalwire-rest/relay-rest/phone-numbers/models/requests.tsp
@@ -81,7 +81,6 @@ model UpdatePhoneNumberRequest {
   call_verto_resource?: string;
 
   @doc("The ID of the Video Room to forward incoming calls to when using the video_room call handler.")
-  @format("uuid")
   call_video_room_id?: uuid;
 
   @doc("The message handler for the phone number.")

--- a/specs/signalwire-rest/relay-rest/queues/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/queues/models/core.tsp
@@ -6,7 +6,6 @@ using Types;
 model QueuePathID {
   @doc("Unique ID of the queue.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -14,7 +13,6 @@ model QueuePathID {
 model QueueIdPath {
   @doc("Unique ID of the queue.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   queue_id: uuid;
 }
@@ -22,7 +20,6 @@ model QueueIdPath {
 model QueueMemberPathID {
   @doc("The unique identifier (ID) of the queue member.")
   @example("596e2dea-a269-4765-a0b4-01b82d11c120")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -31,12 +28,10 @@ model QueueMemberPathID {
 model Queue {
   @doc("The unique identifier of the queue.")
   @example("aae131db-214c-46f5-88b6-92004f8467cf")
-  @format("uuid")
   id: uuid;
 
   @doc("The project ID associated with this queue.")
   @example("c6c4679b-716a-456a-9e41-a03821005005")
-  @format("uuid")
   project_id: uuid;
 
   @doc("The friendly name of the queue.")
@@ -70,7 +65,6 @@ model Queue {
 model QueueMember {
   @doc("The call ID of the queue member.")
   @example("596e2dea-a269-4765-a0b4-01b82d11c120")
-  @format("uuid")
   call_id: uuid;
 
   @doc("The ID of the project associated with this queue member.")

--- a/specs/signalwire-rest/relay-rest/recordings/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/recordings/models/core.tsp
@@ -6,7 +6,6 @@ using Types;
 model RecordingPathID {
   @doc("Unique ID of the recording.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -15,12 +14,10 @@ model RecordingPathID {
 model RecordingBase {
   @doc("Unique ID of the recording.")
   @example("d369a402-7b43-4512-8735-9d5e1f387814")
-  @format("uuid")
   id: uuid;
 
   @doc("Unique ID of the project.")
   @example("d369a402-7b43-4512-8735-9d5e1f387814")
-  @format("uuid")
   project_id: uuid;
 
   @doc("Date and time when the recording was created.")
@@ -70,7 +67,6 @@ model PstnRecording {
   ...RecordingBase;
 
   @doc("ID of the PSTN leg associated with the recording.")
-  @format("uuid")
   relay_pstn_leg_id: uuid;
 }
 
@@ -79,7 +75,6 @@ model SipRecording {
   ...RecordingBase;
 
   @doc("ID of the SIP leg associated with the recording.")
-  @format("uuid")
   relay_sip_leg_id: uuid;
 }
 
@@ -88,7 +83,6 @@ model WebRtcRecording {
   ...RecordingBase;
 
   @doc("ID of the WebRTC leg associated with the recording.")
-  @format("uuid")
   relay_webrtc_leg_id: uuid;
 }
 

--- a/specs/signalwire-rest/relay-rest/short-codes/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/short-codes/models/core.tsp
@@ -7,7 +7,6 @@ using Types;
 model ShortCodePathID {
   @doc("Unique ID of the short code.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -46,7 +45,6 @@ enum ShortCodeMessageHandler {
 model ShortCode {
   @doc("The unique identifier of the short code.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("The name given to the short code.")
@@ -106,7 +104,6 @@ model ShortCode {
 
   @doc("The ID of the LāML application to handle messages when using laml_application handler.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   message_laml_application_id: uuid | null;
 
   @doc("The Relay context to use when using relay_context handler.")

--- a/specs/signalwire-rest/relay-rest/short-codes/models/requests.tsp
+++ b/specs/signalwire-rest/relay-rest/short-codes/models/requests.tsp
@@ -28,7 +28,6 @@ model UpdateShortCodeRequest {
 
   @doc("The ID of the LāML application to handle messages when using laml_application handler.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   message_laml_application_id?: uuid;
 
   @doc("The Relay context to use when using relay_context handler.")

--- a/specs/signalwire-rest/relay-rest/sip-endpoints/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/sip-endpoints/models/core.tsp
@@ -6,7 +6,6 @@ using Types;
 model SipEndpointPathID {
   @doc("Unique ID of the SIP endpoint.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -34,7 +33,6 @@ model SipEndpoint {
 
   @doc("The unique identifier of the SIP endpoint.")
   @example("67075301-69b2-4fc3-8a2c-c95a69a5665e")
-  @format("uuid")
   id: uuid;
 
   @doc("The username for the SIP endpoint.")
@@ -65,7 +63,6 @@ model SipEndpoint {
 
   @doc("The unique identifier of the calling handler resource.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  @format("uuid")
   calling_handler_resource_id: uuid | null;
 
   @doc("A string representing the LaML URL to access when a call is received. This is only used (and required) when call_handler is set to laml_webhooks.")
@@ -114,7 +111,6 @@ model SipEndpoint {
   call_relay_application: string | null;
 
   @doc("A string representing the ID of the Video Room to forward incoming calls to. This is only used (and required) when call_handler is set to video_room.")
-  @format("uuid")
   call_video_room_id: uuid | null;
 
   @doc("A string representing a URL of a SWML script to respond to incoming calls. This is only used (and required) when call_handler is set to relay_script.")

--- a/specs/signalwire-rest/relay-rest/sip-endpoints/models/requests.tsp
+++ b/specs/signalwire-rest/relay-rest/sip-endpoints/models/requests.tsp
@@ -93,19 +93,16 @@ model CreateSipEndpointRequest {
   call_relay_application?: string;
 
   @doc("The ID of the Video Room to forward incoming calls to. Required when call_handler is video_room.")
-  @format("uuid")
-  call_video_room_id?: string;
+  call_video_room_id?: uuid;
 
   @doc("The ID of the Call Flow to forward incoming calls to. Required when call_handler is call_flow.")
-  @format("uuid")
-  call_flow_id?: string;
+  call_flow_id?: uuid;
 
   @doc("The version of the Call Flow to use. Valid values are 'working_copy' or 'current_deployed'.")
   call_flow_version?: string;
 
   @doc("The ID of the AI Agent to forward incoming calls to. Required when call_handler is ai_agent.")
-  @format("uuid")
-  call_ai_agent_id?: string;
+  call_ai_agent_id?: uuid;
 
   @doc("A URL of a SWML script to respond to incoming calls. Required when call_handler is relay_script.")
   @example("https://dev.signalwire.com/relay-bins/f9d13f68-f71e-4042-95bb-b07b9e2f2f92")
@@ -203,19 +200,16 @@ model UpdateSipEndpointRequest {
   call_relay_application?: string;
 
   @doc("The ID of the Video Room to forward incoming calls to. Required when call_handler is video_room.")
-  @format("uuid")
-  call_video_room_id?: string;
+  call_video_room_id?: uuid;
 
   @doc("The ID of the Call Flow to forward incoming calls to. Required when call_handler is call_flow.")
-  @format("uuid")
-  call_flow_id?: string;
+  call_flow_id?: uuid;
 
   @doc("The version of the Call Flow to use. Valid values are 'working_copy' or 'current_deployed'.")
   call_flow_version?: string;
 
   @doc("The ID of the AI Agent to forward incoming calls to. Required when call_handler is ai_agent.")
-  @format("uuid")
-  call_ai_agent_id?: string;
+  call_ai_agent_id?: uuid;
 
   @doc("A URL of a SWML script to respond to incoming calls. Required when call_handler is relay_script.")
   @example("https://dev.signalwire.com/relay-bins/f9d13f68-f71e-4042-95bb-b07b9e2f2f92")

--- a/specs/signalwire-rest/relay-rest/verified-caller-ids/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/verified-caller-ids/models/core.tsp
@@ -6,7 +6,6 @@ using Types;
 model VerifiedCallerIDPathID {
   @doc("Unique ID of the verified caller ID.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   @path
   id: uuid;
 }
@@ -19,7 +18,6 @@ model VerifiedCallerID {
 
   @doc("The unique identifier of the Verified Caller ID on SignalWire.")
   @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
-  @format("uuid")
   id: uuid;
 
   @doc("String representing the phone number for the caller ID. This must be a valid, routeable phone number in E.164 format.")

--- a/specs/signalwire-rest/types/scalar-types/main.tsp
+++ b/specs/signalwire-rest/types/scalar-types/main.tsp
@@ -1,10 +1,5 @@
-import "@typespec/http";
-
-using TypeSpec.Http;
-
-@format("uuid")
-@doc("Universal Unique Identifier.")
-scalar uuid extends string;
-
-@format("jwt")
-scalar jwt extends string;
+// `uuid` and `jwt` scalars live in `_shared/types/main.tsp` so they are
+// reachable from every spec project (signalwire-rest + compatibility-api).
+// This file re-imports them so existing `import "../../types"` chains in
+// signalwire-rest keep working without changes.
+import "../../../_shared/types/main.tsp";

--- a/specs/signalwire-rest/video-api/conference-tokens/models/core.tsp
+++ b/specs/signalwire-rest/video-api/conference-tokens/models/core.tsp
@@ -8,18 +8,16 @@ namespace SignalWireAPI.Video;
 
 model ConferenceTokenPathID {
   @path
-  @format("uuid")
   @doc("Unique ID of the conference token.")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 }
 
 @doc("A conference token object.")
 model ConferenceToken {
   @doc("Unique identifier for the conference token.")
-  @format("uuid")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 
   @doc("Name of the conference token.")
   @example("My First Token")

--- a/specs/signalwire-rest/video-api/conferences/models/core.tsp
+++ b/specs/signalwire-rest/video-api/conferences/models/core.tsp
@@ -20,10 +20,9 @@ enum ConferenceSize {
 
 model ConferencePathID {
   @path
-  @format("uuid")
   @doc("Unique ID of the video conference.")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 }
 
 @doc("Theme color properties for a conference.")
@@ -72,9 +71,8 @@ model ConferenceThemeColors {
 @doc("Video conference response object.")
 model Conference {
   @doc("Unique ID of the video conference.")
-  @format("uuid")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 
   @doc("A named unique identifier for the conference. Allowed characters: `A-Za-z0-9_-`.")
   @example("my_conference")

--- a/specs/signalwire-rest/video-api/logs/models/core.tsp
+++ b/specs/signalwire-rest/video-api/logs/models/core.tsp
@@ -8,10 +8,9 @@ namespace SignalWireAPI.Video;
 @doc("Path parameter for log ID.")
 model LogPathID {
   @path
-  @format("uuid")
   @doc("Unique ID of the log.")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 }
 
 @doc("Source of a video log entry.")
@@ -52,9 +51,8 @@ model ChargeDetail {
 @doc("Log object representing a video activity entry.")
 model Log {
   @doc("A unique identifier for the log.")
-  @format("uuid")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 
   @doc("Source of this log entry.")
   @example(LogSource.realtime_api)
@@ -104,10 +102,9 @@ model Log {
 @summary("Deleted Log")
 @doc("A discarded/deleted video log entry. Returned when the log has been deleted. Only present when `include_deleted` is `true`.")
 model DiscardedLog {
-  @format("uuid")
   @doc("A unique identifier for the log.")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 
   @doc("Date and time when the log was discarded.")
   @example(utcDateTime.fromISO("2022-01-01T10:00:00Z"))

--- a/specs/signalwire-rest/video-api/room-recordings/main.tsp
+++ b/specs/signalwire-rest/video-api/room-recordings/main.tsp
@@ -38,7 +38,7 @@ namespace SignalWireAPI.Video.RoomRecordings {
 
       @query
       @doc("Generated media links will be valid for this many seconds. Default is 900 (15 minutes).")
-      @minValueExclusive(0)
+      @minValue(0)
       @example(900)
       media_ttl?: int32,
     ):

--- a/specs/signalwire-rest/video-api/room-recordings/models/core.tsp
+++ b/specs/signalwire-rest/video-api/room-recordings/models/core.tsp
@@ -7,8 +7,7 @@ namespace SignalWireAPI.Video;
 
 model RoomRecordingPathID {
   @path
-  @format("uuid")
   @doc("Unique ID of the Room Recording.")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 }

--- a/specs/signalwire-rest/video-api/room-recordings/models/requests.tsp
+++ b/specs/signalwire-rest/video-api/room-recordings/models/requests.tsp
@@ -10,7 +10,7 @@ model ListRoomRecordingsRequest {
   @doc("Generated media links will be valid for this many seconds. Default is 900 (15 minutes).")
   @example(900)
   @query
-  @minValueExclusive(0)
+  @minValue(0)
   media_ttl?: int32;
 
   @doc("Page number to return. Requires `page_token` for values greater than 0.")

--- a/specs/signalwire-rest/video-api/room-sessions/models/core.tsp
+++ b/specs/signalwire-rest/video-api/room-sessions/models/core.tsp
@@ -32,23 +32,20 @@ enum RoomRecordingStatus {
 
 model RoomSessionPathID {
   @path
-  @format("uuid")
   @doc("Unique ID of the Room Session.")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 }
 
 @doc("Room session response object.")
 model RoomSession {
   @doc("Unique ID of the session.")
-  @format("uuid")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 
   @doc("Unique ID of the Room if the Session was created from a Room and was not an auto-created Session. Null if the room was set to delete on end.")
-  @format("uuid")
   @example("a1b2c3d4-5e6f-7890-abcd-ef1234567890")
-  room_id: string | null;
+  room_id: uuid | null;
 
   @doc("The named identifier of the room session.")
   @example("my_example_room")
@@ -162,14 +159,12 @@ model RoomSession {
 @doc("Room recording response object.")
 model RoomRecording {
   @doc("Unique ID of the Room Recording.")
-  @format("uuid")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 
   @doc("Unique ID of the Room Session the Room Recording was made in.")
-  @format("uuid")
   @example("a1b2c3d4-5e6f-7890-abcd-ef1234567890")
-  room_session_id: string;
+  room_session_id: uuid;
 
   @doc("Status of the recording.")
   @example(RoomRecordingStatus.completed)
@@ -215,14 +210,12 @@ model RoomRecording {
 @doc("Room session member response object.")
 model RoomSessionMember {
   @doc("Unique ID of the Member.")
-  @format("uuid")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 
   @doc("Unique ID of the Room Session.")
-  @format("uuid")
   @example("a1b2c3d4-5e6f-7890-abcd-ef1234567890")
-  room_session_id: string;
+  room_session_id: uuid;
 
   @doc("Display name of the Member.")
   @example("John Smith")
@@ -248,34 +241,28 @@ model RoomSessionMember {
 @doc("Room session event response object.")
 model RoomSessionEvent {
   @doc("Unique ID of the event.")
-  @format("uuid")
   @example("e44f56a8-7c69-6153-b45c-ab3456789012")
-  id: string;
+  id: uuid;
 
   @doc("The ID of the project.")
-  @format("uuid")
   @example("a1b2c3d4-5e6f-7890-abcd-ef1234567890")
-  project_id: string;
+  project_id: uuid;
 
   @doc("The ID of the room.")
-  @format("uuid")
   @example("b2c3d4e5-6f70-8901-bcde-f12345678901")
-  room_id: string;
+  room_id: uuid;
 
   @doc("The ID of the room session.")
-  @format("uuid")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  room_session_id: string;
+  room_session_id: uuid;
 
   @doc("The ID of the associated room recording. Only present for recording-related events.")
-  @format("uuid")
   @example("d33e35f7-6b58-5042-a34b-ef2345678901")
-  room_recording_id?: string;
+  room_recording_id?: uuid;
 
   @doc("The ID of the associated room participant. Only present for participant-related events.")
-  @format("uuid")
   @example("e44f68a9-7c69-6153-b56d-ef3456789012")
-  room_participant_id?: string;
+  room_participant_id?: uuid;
 
   @doc("The severity level of the event.")
   @example("info")

--- a/specs/signalwire-rest/video-api/room-sessions/models/requests.tsp
+++ b/specs/signalwire-rest/video-api/room-sessions/models/requests.tsp
@@ -1,5 +1,6 @@
 import "@typespec/http";
 import "./core.tsp";
+import "../../../../_shared/types";
 
 using TypeSpec.Http;
 
@@ -11,8 +12,7 @@ model ListRoomSessionsRequest {
   @doc("Return Sessions started from this Room.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
   @query
-  @format("uuid")
-  room_id?: string;
+  room_id?: uuid;
 
   @doc("Return Sessions with a matching room name.")
   @example("my_example_room")
@@ -53,7 +53,7 @@ model ListRoomSessionRecordingsRequest {
   @doc("Generated media links will be valid for this many seconds. Default is 900 (15 minutes).")
   @example(900)
   @query
-  @minValueExclusive(0)
+  @minValue(0)
   media_ttl?: int32;
 
   @doc("Page number to return. Requires `page_token` for values greater than 0.")

--- a/specs/signalwire-rest/video-api/rooms/main.tsp
+++ b/specs/signalwire-rest/video-api/rooms/main.tsp
@@ -100,10 +100,9 @@ namespace SignalWireAPI.Video.Rooms {
     @route("/{id}")
     read(
       @path
-      @format("uuid")
       @doc("Unique ID of the room.")
       @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-      id: string,
+      id: uuid,
 
       @query
       @doc("Specifies whether or not to include information about the room's active session (if any).")
@@ -124,10 +123,9 @@ namespace SignalWireAPI.Video.Rooms {
     @put
     update(
       @path
-      @format("uuid")
       @doc("Unique ID of the room.")
       @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-      id: string,
+      id: uuid,
 
       @body body: UpdateRoomRequest,
     ):
@@ -145,10 +143,9 @@ namespace SignalWireAPI.Video.Rooms {
     @delete
     delete(
       @path
-      @format("uuid")
       @doc("Unique ID of the room.")
       @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-      id: string,
+      id: uuid,
     ):
       | {
           @statusCode statusCode: 204;

--- a/specs/signalwire-rest/video-api/rooms/models/responses.tsp
+++ b/specs/signalwire-rest/video-api/rooms/models/responses.tsp
@@ -8,8 +8,7 @@ namespace SignalWireAPI.Video;
 model RoomResponse {
   @doc("A unique identifier for the room.")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  @format("uuid")
-  id: string;
+  id: uuid;
 
   @doc("A named unique identifier for the room.")
   @example("my_room")

--- a/specs/signalwire-rest/video-api/streams/models/core.tsp
+++ b/specs/signalwire-rest/video-api/streams/models/core.tsp
@@ -7,26 +7,23 @@ namespace SignalWireAPI.Video;
 
 model StreamPathID {
   @path
-  @format("uuid")
   @doc("Unique ID of the stream.")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 }
 
 model RoomPathID {
   @path
-  @format("uuid")
   @doc("Unique ID of the video room.")
   @example("fe4093d9-58c2-4931-b4b9-5679f82652c6")
-  id: string;
+  id: uuid;
 }
 
 @doc("A video stream object.")
 model Stream {
   @doc("Unique identifier for the stream.")
-  @format("uuid")
   @example("c22d24f6-5a47-4597-9a23-c7d01e696b92")
-  id: string;
+  id: uuid;
 
   @doc("RTMP or RTMPS URL. This must be the address of a server accepting incoming RTMP/RTMPS streams.")
   @example("rtmp://broadcaster")

--- a/specs/signalwire-rest/voice-api/logs/models/core.tsp
+++ b/specs/signalwire-rest/voice-api/logs/models/core.tsp
@@ -9,7 +9,6 @@ namespace SignalWireAPI.Voice;
 
 
 model LogPathID {
-  @format("uuid")
   @path
   @doc("Unique ID of the log. This is the segment_id you can find in Relay call details in your Dashboard UI or in return objects when using the SDK.")
   @example("b7182dc2-00f3-40e4-a5ce-20f164b329df")
@@ -29,7 +28,6 @@ model ChargeDetail {
 
 @doc("Common fields shared across all voice log types.")
 model VoiceLogCommon {
-  @format("uuid")
   @doc("A unique identifier for the log.")
   @example("b7182dc2-00f3-40e4-a5ce-20f164b329df")
   id: uuid;
@@ -174,7 +172,6 @@ model FabricVoiceLog {
 @summary("Deleted Log")
 @doc("A discarded/deleted voice log entry. Returned when the log has been deleted. Only present when `include_deleted` is `true`.")
 model DiscardedVoiceLog {
-  @format("uuid")
   @doc("A unique identifier for the log.")
   @example("b7182dc2-00f3-40e4-a5ce-20f164b329df")
   id: uuid;
@@ -215,12 +212,10 @@ model LogEvent {
   @example(#{})
   details: {};
 
-  @format("uuid")
   @doc("Unique identifier for the project.")
   @example("b7182dc2-00f3-40e4-a5ce-20f164b329df")
   project_id: uuid;
 
-  @format("uuid")
   @doc("Unique identifier for the log.")
   @example("b7182dc2-00f3-40e4-a5ce-20f164b329df")
   log_id: uuid;


### PR DESCRIPTION
Mechanical drag-along cleanup extracted from the upcoming SWML messaging schema work, kept independent so the messaging PR stays focused on actual messaging changes.

### What this does

1. **Hoists the `uuid` and `jwt` scalars** from `specs/signalwire-rest/types/scalar-types/main.tsp` up to `specs/_shared/types/main.tsp` so both signalwire-rest and compatibility-api can reach them without crossing project boundaries. The old file becomes a re-import shim, preserving every existing `import "../../types"` chain in signalwire-rest.

2. **Collapses ~115 `@format("uuid") + string` pairs to a bare `uuid` scalar** across signalwire-rest and compatibility-api. The pattern is consistent everywhere:

   \`\`\`diff
      @doc("...")
      @example("...")
   -  @format("uuid")
      @path
   -  id: string;
   +  id: uuid;
   \`\`\`

### Why it's safe

The `uuid` scalar (`@format("uuid") scalar uuid extends string`) already carries `format: uuid` at the type level. A sibling `@format("uuid")` decorator on the property emits a redundant `format: uuid` next to the `$ref` in the OpenAPI Parameter Object's schema — valid OpenAPI 3.1 but pure noise. Stripping it produces byte-equivalent generated `openapi.yaml` for the parameter shapes; the diff in `fern/apis/*/openapi.yaml` is just the deduplication.

**Zero behavior changes.** No new fields, no removed fields, no type changes for any caller. Same OpenAPI Schema Objects for every resource.

### Scope

* 116 `.tsp` source files (compatibility-api + signalwire-rest)
* 1 new shared scalar file (`specs/_shared/types/main.tsp`)
* 1 shim file (`specs/signalwire-rest/types/scalar-types/main.tsp`)
* 2 regenerated `openapi.yaml` files (mechanical byproduct)

### Out of scope (deliberately)

* `UrlMethodType` → `RequestUrlMethodType` rename — coupled to the messaging PR via `swml-scripts/core.tsp`, so it stays there.
* The actual SWML messaging schema work — lands separately in [#315](https://github.com/signalwire/docs/pull/315).

### Verification

\`\`\`bash
cd specs && yarn build:api
\`\`\`

Both signalwire-rest and compatibility-api compile cleanly under TypeSpec 1.11.0.

### Followup

Once this merges, [#315 (SWML schema PR)](https://github.com/signalwire/docs/pull/315) gets rebased — its file count drops from 242 to ~117, leaving only changes that are genuinely about SWML messaging.