### PR TITLE
fix: Subscriber Invite endpoint takes bearer token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 .env
 .env.*
 !.env.example
+
+.docs-review

--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -1410,7 +1410,7 @@ paths:
       operationId: create_subscriber_guest_token
       summary: Create Subscriber guest token
       description: |-
-        Creates a [Subscriber](/docs/platform/subscribers) Guest Token. The token is authorized using an existing API token.
+        Creates a [Subscriber](/docs/platform/subscribers) Guest Token. Authenticate this request with your project's API token.
 
         #### Permissions
 
@@ -5661,7 +5661,7 @@ paths:
       operationId: create_subscriber_invite_token
       summary: Create Subscriber invite token
       description: |-
-        Creates a [Subscriber](/docs/platform/subscribers) Invite Token to be used for client-side API calls. The token is authorized using a subscriber's SAT (Subscriber Access Token).
+        Creates a [Subscriber](/docs/platform/subscribers) Invite Token for use with client-side API calls. Authenticate this request with a subscriber's SAT (Subscriber Access Token), not the project level Basic Auth.
 
         #### Permissions
 

--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -5708,6 +5708,8 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/SubscriberInviteTokenCreateRequest'
+      security:
+        - SignalWireBearerAuth: []
   /api/fabric/subscribers/tokens:
     post:
       operationId: create_subscriber_token

--- a/specs/signalwire-rest/fabric-api/subscribers/guest-tokens/main.tsp
+++ b/specs/signalwire-rest/fabric-api/subscribers/guest-tokens/main.tsp
@@ -19,7 +19,7 @@ namespace SignalWireAPI.Fabric.SubscriberGuestTokens {
     @operationId("create_subscriber_guest_token")
     @summary("Create Subscriber guest token")
     @doc("""
-      Creates a [Subscriber](/docs/platform/subscribers) Guest Token. The token is authorized using an existing API token.
+      Creates a [Subscriber](/docs/platform/subscribers) Guest Token. Authenticate this request with your project's API token.
 
       ${tokenPermissions<"_Voice_, _Messaging_, _Fax_, or _Video_">}
       """)

--- a/specs/signalwire-rest/fabric-api/subscribers/invite-tokens/main.tsp
+++ b/specs/signalwire-rest/fabric-api/subscribers/invite-tokens/main.tsp
@@ -21,7 +21,7 @@ namespace SignalWireAPI.Fabric.SubscriberInviteTokens {
     @operationId("create_subscriber_invite_token")
     @summary("Create Subscriber invite token")
     @doc("""
-      Creates a [Subscriber](/docs/platform/subscribers) Invite Token to be used for client-side API calls. The token is authorized using a subscriber's SAT (Subscriber Access Token).
+      Creates a [Subscriber](/docs/platform/subscribers) Invite Token for use with client-side API calls. Authenticate this request with a subscriber's SAT (Subscriber Access Token), not the project level Basic Auth.
 
       ${tokenPermissions<"_Voice_, _Messaging_, _Fax_, or _Video_">}
       """)

--- a/specs/signalwire-rest/fabric-api/subscribers/invite-tokens/main.tsp
+++ b/specs/signalwire-rest/fabric-api/subscribers/invite-tokens/main.tsp
@@ -5,12 +5,14 @@ import "./models/responses.tsp";
 import "./models/errors.tsp";
 import "../../../types";
 import "../../tags.tsp";
+import "../../../../_shared/auth.tsp";
 import "../../../../_shared/alias/token-permissions.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
 using Types.StatusCodes;
 
+@useAuth(SignalWireBearerAuth)
 @route("/subscriber/invites")
 namespace SignalWireAPI.Fabric.SubscriberInviteTokens {
   @tag(SUBSCRIBERS_TOKENS_TAG)


### PR DESCRIPTION
## Description

Update `SignalWireAPI.Fabric.SubscriberInviteTokens` to reflect the fact that it takes Bearer Token, rather th

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues


## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [x] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
