### PR TITLE
ci: install fern-api globally in workflows that invoke fern

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Install Fern CLI
+        run: npm install -g fern-api
+
       - name: Check API is valid
         run: yarn fern-check
         env:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Install Fern CLI
+        run: npm install -g fern-api
+
       - name: Build TypeSpec specifications
         run: yarn build:specs
 


### PR DESCRIPTION
## Summary
- `yarn install` doesn't put `fern` on PATH (it's not a workspace dependency), so `yarn fern-check` fails in CI with `/bin/sh: 1: fern: not found`.
- Add a `npm install -g fern-api` step in `check.yml` and `publish-docs.yml` — the two workflows that invoke the `fern` binary via `yarn fern-check` / `yarn fern-md-check`.
- `publish-postman.yml` and `check-links.yml` don't run fern, so they're untouched.

## Test plan
- [ ] Verify the `fern-check` workflow passes on this PR
- [ ] Verify the `publish-docs` workflow runs on next merge to main