### PR TITLE
ci: pin fern-api to 5.26.4 and drop global CLI install steps

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Install Fern CLI
-        run: npm install -g fern-api
-
       - name: Check API is valid
         run: yarn fern-check
         env:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,9 +21,6 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Install Fern CLI
-        run: npm install -g fern-api
-
       - name: Build TypeSpec specifications
         run: yarn build:specs
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "postman:publish": "node scripts/postman/build-collection.mjs publish"
   },
   "devDependencies": {
-    "fern-api": "^5.23.3",
+    "fern-api": "5.26.4",
     "js-yaml": "^4.1.0",
     "openapi-to-postmanv2": "6.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -623,10 +623,10 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
-fern-api@^5.23.3:
-  version "5.23.3"
-  resolved "https://registry.yarnpkg.com/fern-api/-/fern-api-5.23.3.tgz#f1f204fd074c45ace02cb1e8b3d9166435c136f3"
-  integrity sha512-LQSwA3Z1Qni5lFyGzM1VcwIFm5jlYA0QJWG+OvkouZ5uyNegSGB3+/TP9AaeC4tQUnx9bzwS5w4AnuKq13VDNg==
+fern-api@5.26.4:
+  version "5.26.4"
+  resolved "https://registry.yarnpkg.com/fern-api/-/fern-api-5.26.4.tgz#d7009b3a0b9d3b08c9e2220a660783a09a180a34"
+  integrity sha512-XdZRDmvgxsB7PbHggLcqNuFCFOLbwV0xlQv5nJskC/406h3LW+pXPgK5On+2RMdjt88v9gYBF6sbgVYZHI0OgQ==
   optionalDependencies:
     "@boundaryml/baml" "^0.219.0"
 


### PR DESCRIPTION
## Summary
- Pins `fern-api` devDependency to `5.26.4`, matching the CLI version declared in `fern/fern.config.json` (was `^5.23.3`).
- Removes the `npm install -g fern-api` steps added in #334 from `check.yml` and `publish-docs.yml`. With `fern-api` as a pinned workspace devDependency, `yarn install` puts `fern` in `node_modules/.bin`, so every workflow that calls `yarn fern-check`, `yarn build`, `npx fern generate`, etc. resolves the binary automatically.
- Refreshes `yarn.lock` to the new resolved version.

This also fixes the `preview-docs.yml` failure (`/bin/sh: 1: fern: not found`) that #334 missed — once branches merge this, the preview workflow's `yarn build` step will find fern via the lockfile.

## Test plan
- [ ] `fern-check` workflow passes on this PR (uses `yarn fern-check` only)
- [ ] `preview-docs` workflow generates a preview URL (uses `yarn build` which calls `fern generate`)
- [ ] After merge, downstream PR branches that pull in main get a working preview