### PR TITLE
Document custom_variables for outbound messages and SWML calls

### DIFF
--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -15593,6 +15593,20 @@ components:
           examples:
             - - us-east-1
               - us-west-2
+        custom_variables:
+          type: object
+          unevaluatedProperties:
+            type: string
+          maxProperties: 20
+          description: |-
+            Your own key/value string pairs to attach to the call. They become environment variables on the call's SWML document, where you can reference them as `${envs.<key>}` — for example, to carry an order or case number through to your call logic. When SignalWire fetches your SWML document from a URL, the same pairs are also included in the `envs` object of that request.
+
+            If a key here matches a variable you've already set at the account or project level, the value you pass on the request takes precedence — but only when the keys match exactly, including case. Keys are case-sensitive, so two keys that differ only in case are kept as separate variables.
+
+            Each value must be a non-empty string of at most 1024 bytes. You can send at most 20 pairs. Each key must start with a letter or underscore and contain only letters, numbers, and underscores, and cannot begin with the reserved prefixes `signalwire_`, `sw_`, `rtc_`, or `internal_` (case-insensitive).
+          examples:
+            - id: '12345'
+              case_number: '54321'
       unevaluatedProperties:
         not: {}
     Calling.CallCreateParamsSWML:
@@ -15700,6 +15714,20 @@ components:
           examples:
             - - us-east-1
               - us-west-2
+        custom_variables:
+          type: object
+          unevaluatedProperties:
+            type: string
+          maxProperties: 20
+          description: |-
+            Your own key/value string pairs to attach to the call. They become environment variables on the call's SWML document, where you can reference them as `${envs.<key>}` — for example, to carry an order or case number through to your call logic. When SignalWire fetches your SWML document from a URL, the same pairs are also included in the `envs` object of that request.
+
+            If a key here matches a variable you've already set at the account or project level, the value you pass on the request takes precedence — but only when the keys match exactly, including case. Keys are case-sensitive, so two keys that differ only in case are kept as separate variables.
+
+            Each value must be a non-empty string of at most 1024 bytes. You can send at most 20 pairs. Each key must start with a letter or underscore and contain only letters, numbers, and underscores, and cannot begin with the reserved prefixes `signalwire_`, `sw_`, `rtc_`, or `internal_` (case-insensitive).
+          examples:
+            - id: '12345'
+              case_number: '54321'
         swml:
           allOf:
             - $ref: '#/components/schemas/SWML.Calling.SWMLObject'
@@ -15812,6 +15840,20 @@ components:
           examples:
             - - us-east-1
               - us-west-2
+        custom_variables:
+          type: object
+          unevaluatedProperties:
+            type: string
+          maxProperties: 20
+          description: |-
+            Your own key/value string pairs to attach to the call. They become environment variables on the call's SWML document, where you can reference them as `${envs.<key>}` — for example, to carry an order or case number through to your call logic. When SignalWire fetches your SWML document from a URL, the same pairs are also included in the `envs` object of that request.
+
+            If a key here matches a variable you've already set at the account or project level, the value you pass on the request takes precedence — but only when the keys match exactly, including case. Keys are case-sensitive, so two keys that differ only in case are kept as separate variables.
+
+            Each value must be a non-empty string of at most 1024 bytes. You can send at most 20 pairs. Each key must start with a letter or underscore and contain only letters, numbers, and underscores, and cannot begin with the reserved prefixes `signalwire_`, `sw_`, `rtc_`, or `internal_` (case-insensitive).
+          examples:
+            - id: '12345'
+              case_number: '54321'
         url:
           type: string
           description: |-
@@ -22511,6 +22553,11 @@ components:
           description: A unique identifier for the current call segment.
           examples:
             - d3e4f5a6-b7c8-9012-defa-345678901bcd
+        tag:
+          type: string
+          description: The tag you assigned to this call when it was created, if any.
+          examples:
+            - support-queue
         call_state:
           type: string
           description: The current state of the call.
@@ -22543,6 +22590,23 @@ components:
           description: The number/URI of the destination of this call.
           examples:
             - sip:destination@yourdomain.com
+        from_number:
+          type: string
+          description: The phone number that initiated this call. Present for phone calls (`type` is `phone`); SIP and WebRTC calls expose the originator through `from` instead.
+          examples:
+            - '+12223334444'
+        to_number:
+          type: string
+          description: The destination phone number of this call. Present for phone calls (`type` is `phone`); SIP and WebRTC calls expose the destination through `to` instead.
+          examples:
+            - '+12223334445'
+        dial_winner:
+          type: string
+          enum:
+            - 'true'
+          description: Set to `"true"` when this call won a parallel dial. Omitted otherwise.
+          examples:
+            - 'true'
         headers:
           type: array
           items:
@@ -22550,6 +22614,14 @@ components:
           description: The headers associated with this call.
           examples:
             - []
+        parent:
+          allOf:
+            - $ref: '#/components/schemas/Fabric.SWMLWebhooks.InboundCallParent'
+          description: The call that created this call. Present only when this call has a parent.
+        peer:
+          allOf:
+            - $ref: '#/components/schemas/Fabric.SWMLWebhooks.InboundCallPeer'
+          description: The call this call is bridged to. Present only when this call has a peer.
         sip_data:
           allOf:
             - $ref: '#/components/schemas/Fabric.SWMLWebhooks.InboundCallSipData'
@@ -22590,6 +22662,56 @@ components:
         not: {}
       description: A single header associated with the call.
       title: Call header
+    Fabric.SWMLWebhooks.InboundCallParent:
+      type: object
+      required:
+        - device_type
+        - call_id
+        - node_id
+      properties:
+        device_type:
+          type: string
+          enum:
+            - sip
+            - phone
+            - webrtc
+          description: The device type of the parent call.
+          examples:
+            - phone
+        call_id:
+          type: string
+          description: A unique identifier for the parent call.
+          examples:
+            - a1b2c3d4-1111-2222-3333-444455556666
+        node_id:
+          type: string
+          description: A unique identifier for the node handling the parent call.
+          examples:
+            - a1b2c3d4-1111-2222-3333-444455556666
+      unevaluatedProperties:
+        not: {}
+      description: The call that created this call. Present only when this call has a parent — for example, a leg created by a `connect` or transfer.
+      title: Parent call
+    Fabric.SWMLWebhooks.InboundCallPeer:
+      type: object
+      required:
+        - call_id
+        - node_id
+      properties:
+        call_id:
+          type: string
+          description: A unique identifier for the peer call.
+          examples:
+            - a1b2c3d4-1111-2222-3333-444455556666
+        node_id:
+          type: string
+          description: A unique identifier for the node handling the peer call.
+          examples:
+            - a1b2c3d4-1111-2222-3333-444455556666
+      unevaluatedProperties:
+        not: {}
+      description: The call this call is bridged to. Present only when this call has a peer.
+      title: Peer call
     Fabric.SWMLWebhooks.InboundCallSipData:
       type: object
       required:
@@ -22704,10 +22826,15 @@ components:
         envs:
           type: object
           unevaluatedProperties: {}
-          description: Environment variables configured at the account or project level.
+          description: |-
+            Environment variables available to this call's SWML document, which you can reference as `${envs.<key>}`. Combines the variables you've configured at the account or project level with any `custom_variables` you passed on the outbound [Call commands](/docs/apis/rest/calls/call-commands) request.
+
+            Keys are case-sensitive. When a `custom_variables` key exactly matches an account- or project-level variable, including case, the value from the request wins; if they differ only in case, both are kept as separate variables.
           examples:
             - api_key: <YOUR_API_KEY>
               webhook_url: https://example.com/webhook
+              id: '12345'
+              case_number: '54321'
         params:
           type: object
           unevaluatedProperties: {}
@@ -24643,6 +24770,18 @@ components:
           description: A valid URL to receive message status callback events at each state change. See the [Message status callback](/docs/apis/rest/messages/webhooks/message-status-callback) webhook for the payload your URL will receive.
           examples:
             - https://example.com/webhooks/message-status
+        custom_variables:
+          type: object
+          unevaluatedProperties:
+            type: string
+          maxProperties: 20
+          description: |-
+            Your own key/value string pairs to attach to the message — for example, an order or case number you want to recognize later. When you also set `status_callback`, SignalWire includes these pairs as a `custom_variables` object in every status callback it sends to that URL, so you can match each callback to a record in your own system. If you don't set `status_callback`, there is nowhere for the variables to be delivered.
+
+            Each value must be a non-empty string of at most 1024 bytes. You can send at most 20 pairs. Each key must start with a letter or underscore and contain only letters, numbers, and underscores, and cannot begin with the reserved prefixes `signalwire_`, `sw_`, `rtc_`, or `internal_` (case-insensitive). Keys are case-sensitive.
+          examples:
+            - id: '12345'
+              case_number: '54321'
       unevaluatedProperties:
         not: {}
       description: Request body for sending a new SMS or MMS message.
@@ -25201,6 +25340,14 @@ components:
           description: Human-readable error message if delivery failed. Null when no error occurred.
           examples:
             - null
+        custom_variables:
+          type: object
+          unevaluatedProperties:
+            type: string
+          description: The same `custom_variables` key/value pairs you supplied when [sending the message](/docs/apis/rest/messages/create-message), echoed back so you can match this callback to a record in your own system. Included only when the message was sent with custom variables.
+          examples:
+            - id: '12345'
+              case_number: '54321'
       unevaluatedProperties:
         not: {}
       description: |-
@@ -45822,6 +45969,15 @@ webhooks:
                     - type: 'null'
                   description: Human-readable error message if delivery failed. Null when no error occurred.
                   example: null
+                custom_variables:
+                  type: object
+                  properties: {}
+                  unevaluatedProperties:
+                    type: string
+                  description: The same `custom_variables` key/value pairs you supplied when [sending the message](/docs/apis/rest/messages/create-message), echoed back so you can match this callback to a record in your own system. Included only when the message was sent with custom variables.
+                  example:
+                    id: '12345'
+                    case_number: '54321'
               required:
                 - id
                 - project_id
@@ -46015,6 +46171,10 @@ webhooks:
                       type: string
                       description: A unique identifier for the current call segment.
                       example: d3e4f5a6-b7c8-9012-defa-345678901bcd
+                    tag:
+                      type: string
+                      description: The tag you assigned to this call when it was created, if any.
+                      example: support-queue
                     call_state:
                       type: string
                       description: The current state of the call.
@@ -46042,6 +46202,20 @@ webhooks:
                       type: string
                       description: The number/URI of the destination of this call.
                       example: sip:destination@yourdomain.com
+                    from_number:
+                      type: string
+                      description: The phone number that initiated this call. Present for phone calls (`type` is `phone`); SIP and WebRTC calls expose the originator through `from` instead.
+                      example: '+12223334444'
+                    to_number:
+                      type: string
+                      description: The destination phone number of this call. Present for phone calls (`type` is `phone`); SIP and WebRTC calls expose the destination through `to` instead.
+                      example: '+12223334445'
+                    dial_winner:
+                      type: string
+                      enum:
+                        - 'true'
+                      description: Set to `"true"` when this call won a parallel dial. Omitted otherwise.
+                      example: 'true'
                     headers:
                       type: array
                       items:
@@ -46063,6 +46237,49 @@ webhooks:
                         description: A single header associated with the call.
                       description: The headers associated with this call.
                       example: []
+                    parent:
+                      type: object
+                      properties:
+                        device_type:
+                          type: string
+                          enum:
+                            - sip
+                            - phone
+                            - webrtc
+                          description: The device type of the parent call.
+                          example: phone
+                        call_id:
+                          type: string
+                          description: A unique identifier for the parent call.
+                          example: a1b2c3d4-1111-2222-3333-444455556666
+                        node_id:
+                          type: string
+                          description: A unique identifier for the node handling the parent call.
+                          example: a1b2c3d4-1111-2222-3333-444455556666
+                      required:
+                        - device_type
+                        - call_id
+                        - node_id
+                      unevaluatedProperties:
+                        not: {}
+                      description: The call that created this call. Present only when this call has a parent.
+                    peer:
+                      type: object
+                      properties:
+                        call_id:
+                          type: string
+                          description: A unique identifier for the peer call.
+                          example: a1b2c3d4-1111-2222-3333-444455556666
+                        node_id:
+                          type: string
+                          description: A unique identifier for the node handling the peer call.
+                          example: a1b2c3d4-1111-2222-3333-444455556666
+                      required:
+                        - call_id
+                        - node_id
+                      unevaluatedProperties:
+                        not: {}
+                      description: The call this call is bridged to. Present only when this call has a peer.
                     sip_data:
                       type: object
                       properties:
@@ -46178,10 +46395,15 @@ webhooks:
                   type: object
                   properties: {}
                   unevaluatedProperties: {}
-                  description: Environment variables configured at the account or project level.
+                  description: |-
+                    Environment variables available to this call's SWML document, which you can reference as `${envs.<key>}`. Combines the variables you've configured at the account or project level with any `custom_variables` you passed on the outbound [Call commands](/docs/apis/rest/calls/call-commands) request.
+
+                    Keys are case-sensitive. When a `custom_variables` key exactly matches an account- or project-level variable, including case, the value from the request wins; if they differ only in case, both are kept as separate variables.
                   example:
                     api_key: <YOUR_API_KEY>
                     webhook_url: https://example.com/webhook
+                    id: '12345'
+                    case_number: '54321'
                 params:
                   type: object
                   properties: {}

--- a/fern/products/apis/pages/core/error-codes.mdx
+++ b/fern/products/apis/pages/core/error-codes.mdx
@@ -231,6 +231,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 - The resource could not be purchased.
 </ParamField>
 
+<ParamField path="custom_variable_value_too_long" type="Error" toc={true}>
+
+- A `custom_variables` value exceeds the maximum size. Each value must be at most 1024 bytes.
+</ParamField>
+
 <ParamField path="destination_number_not_supported" type="Error" toc={true}>
 
 - The destination phone number is not supported.
@@ -336,6 +341,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 - This account has an insufficient balance.
 </ParamField>
 
+<ParamField path="insufficient_balance_to_receive_message" type="Error" toc={true}>
+
+- The account has an insufficient balance to receive the message.
+</ParamField>
+
 <ParamField path="integration_test_verified_caller_required" type="Error" toc={true}>
 
 - The `to` number must be the verified caller ID for the trial campaign.
@@ -389,6 +399,16 @@ The `code` field above maps to one of the values below. Each entry describes the
 <ParamField path="invalid_content_type" type="Error" toc={true}>
 
 - Invalid content type.
+</ParamField>
+
+<ParamField path="invalid_custom_variable_name" type="Error" toc={true}>
+
+- A `custom_variables` key is invalid. Keys must start with a letter or underscore and contain only letters, numbers, and underscores.
+</ParamField>
+
+<ParamField path="invalid_custom_variable_value" type="Error" toc={true}>
+
+- A `custom_variables` value is invalid. Values must be non-empty strings.
 </ParamField>
 
 <ParamField path="invalid_destination_number" type="Error" toc={true}>
@@ -636,6 +656,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 - Value must be an array of `{name, value}` objects.
 </ParamField>
 
+<ParamField path="must_be_object" type="Error" toc={true}>
+
+- The `custom_variables` parameter must be an object of string key/value pairs.
+</ParamField>
+
 <ParamField path="must_belong_to_project" type="Error" toc={true}>
 
 - The requested resource must belong to the project being used to authenticate the request.
@@ -871,6 +896,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 - The rate limit has been exceeded.
 </ParamField>
 
+<ParamField path="reserved_custom_variable_name" type="Error" toc={true}>
+
+- A `custom_variables` key uses a reserved prefix. The prefixes `signalwire_`, `sw_`, `rtc_`, and `internal_` are reserved for internal use and cannot be used in your own keys.
+</ParamField>
+
 <ParamField path="reserved_header_name" type="Error" toc={true}>
 
 - The provided header name is reserved and cannot be set by the caller.
@@ -989,6 +1019,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 <ParamField path="token_not_associated_with_video_room" type="Error" toc={true}>
 
 - The provided token is not associated with a valid video room.
+</ParamField>
+
+<ParamField path="too_many_custom_variables" type="Error" toc={true}>
+
+- The request contains too many custom variables. A maximum of 20 keys is allowed.
 </ParamField>
 
 <ParamField path="too_many_headers" type="Error" toc={true}>

--- a/specs/signalwire-rest/calling-api/calls/models/requests.tsp
+++ b/specs/signalwire-rest/calling-api/calls/models/requests.tsp
@@ -1,10 +1,12 @@
 import "@typespec/http";
 import "@typespec/openapi3";
+import "@typespec/json-schema";
 import "../../../../swml/calling";
 import "./core.tsp";
 
 using TypeSpec.Http;
 using TypeSpec.OpenAPI;
+using TypeSpec.JsonSchema;
 
 namespace SignalWireAPI.Calling;
 
@@ -462,6 +464,17 @@ model CallCreateParamsBase {
   @doc("Preferred FreeSWITCH region(s) for call routing. Must be drawn from the project's available regions. Accepts a single region or a priority-ordered array.")
   @example(#["us-east-1", "us-west-2"])
   region?: string | string[];
+
+  @maxProperties(20)
+  @doc("""
+    Your own key/value string pairs to attach to the call. They become environment variables on the call's SWML document, where you can reference them as `\${envs.<key>}` — for example, to carry an order or case number through to your call logic. When SignalWire fetches your SWML document from a URL, the same pairs are also included in the `envs` object of that request.
+
+    If a key here matches a variable you've already set at the account or project level, the value you pass on the request takes precedence — but only when the keys match exactly, including case. Keys are case-sensitive, so two keys that differ only in case are kept as separate variables.
+
+    Each value must be a non-empty string of at most 1024 bytes. You can send at most 20 pairs. Each key must start with a letter or underscore and contain only letters, numbers, and underscores, and cannot begin with the reserved prefixes `signalwire_`, `sw_`, `rtc_`, or `internal_` (case-insensitive).
+    """)
+  @example(#{ id: "12345", case_number: "54321" })
+  custom_variables?: TypeSpec.Record<string>;
 }
 
 @summary("dial (URL)")

--- a/specs/signalwire-rest/fabric-api/swml-webhook/models/webhooks.tsp
+++ b/specs/signalwire-rest/fabric-api/swml-webhook/models/webhooks.tsp
@@ -167,6 +167,34 @@ model InboundCallSipData {
   };
 }
 
+@summary("Parent call")
+@doc("The call that created this call. Present only when this call has a parent — for example, a leg created by a `connect` or transfer.")
+model InboundCallParent {
+  @doc("The device type of the parent call.")
+  @example("phone")
+  device_type: "sip" | "phone" | "webrtc";
+
+  @doc("A unique identifier for the parent call.")
+  @example("a1b2c3d4-1111-2222-3333-444455556666")
+  call_id: string;
+
+  @doc("A unique identifier for the node handling the parent call.")
+  @example("a1b2c3d4-1111-2222-3333-444455556666")
+  node_id: string;
+}
+
+@summary("Peer call")
+@doc("The call this call is bridged to. Present only when this call has a peer.")
+model InboundCallPeer {
+  @doc("A unique identifier for the peer call.")
+  @example("a1b2c3d4-1111-2222-3333-444455556666")
+  call_id: string;
+
+  @doc("A unique identifier for the node handling the peer call.")
+  @example("a1b2c3d4-1111-2222-3333-444455556666")
+  node_id: string;
+}
+
 @summary("Inbound call")
 @doc("Information about the call that triggered the SWML document fetch.")
 model InboundCallContext {
@@ -181,6 +209,10 @@ model InboundCallContext {
   @doc("A unique identifier for the current call segment.")
   @example("d3e4f5a6-b7c8-9012-defa-345678901bcd")
   segment_id: string;
+
+  @doc("The tag you assigned to this call when it was created, if any.")
+  @example("support-queue")
+  tag?: string;
 
   @doc("The current state of the call.")
   @example("created")
@@ -202,9 +234,27 @@ model InboundCallContext {
   @example("sip:destination@yourdomain.com")
   to: string;
 
+  @doc("The phone number that initiated this call. Present for phone calls (`type` is `phone`); SIP and WebRTC calls expose the originator through `from` instead.")
+  @example("+12223334444")
+  from_number?: string;
+
+  @doc("The destination phone number of this call. Present for phone calls (`type` is `phone`); SIP and WebRTC calls expose the destination through `to` instead.")
+  @example("+12223334445")
+  to_number?: string;
+
+  @doc("Set to `\"true\"` when this call won a parallel dial. Omitted otherwise.")
+  @example("true")
+  dial_winner?: "true";
+
   @doc("The headers associated with this call.")
   @example(#[])
   headers: InboundCallHeader[];
+
+  @doc("The call that created this call. Present only when this call has a parent.")
+  parent?: InboundCallParent;
+
+  @doc("The call this call is bridged to. Present only when this call has a peer.")
+  peer?: InboundCallPeer;
 
   @doc("SIP-specific data. Present only when `type` is `sip`.")
   sip_data?: InboundCallSipData;
@@ -234,10 +284,16 @@ model InboundCallWebhookPayload {
     ...TypeSpec.Record<unknown>;
   };
 
-  @doc("Environment variables configured at the account or project level.")
+  @doc("""
+    Environment variables available to this call's SWML document, which you can reference as `\${envs.<key>}`. Combines the variables you've configured at the account or project level with any `custom_variables` you passed on the outbound [Call commands](/docs/apis/rest/calls/call-commands) request.
+
+    Keys are case-sensitive. When a `custom_variables` key exactly matches an account- or project-level variable, including case, the value from the request wins; if they differ only in case, both are kept as separate variables.
+    """)
   @example(#{
     api_key: "<YOUR_API_KEY>",
     webhook_url: "https://example.com/webhook",
+    id: "12345",
+    case_number: "54321",
   })
   envs: {
     ...TypeSpec.Record<unknown>;

--- a/specs/signalwire-rest/message-api/messages/models/requests.tsp
+++ b/specs/signalwire-rest/message-api/messages/models/requests.tsp
@@ -1,7 +1,9 @@
 import "@typespec/http";
+import "@typespec/json-schema";
 import "./core.tsp";
 
 using TypeSpec.Http;
+using TypeSpec.JsonSchema;
 
 namespace SignalWireAPI.Message;
 
@@ -30,6 +32,15 @@ model CreateMessageRequest {
   @doc("A valid URL to receive message status callback events at each state change. See the [Message status callback](/docs/apis/rest/messages/webhooks/message-status-callback) webhook for the payload your URL will receive.")
   @example("https://example.com/webhooks/message-status")
   status_callback?: url;
+
+  @doc("""
+    Your own key/value string pairs to attach to the message — for example, an order or case number you want to recognize later. When you also set `status_callback`, SignalWire includes these pairs as a `custom_variables` object in every status callback it sends to that URL, so you can match each callback to a record in your own system. If you don't set `status_callback`, there is nowhere for the variables to be delivered.
+
+    Each value must be a non-empty string of at most 1024 bytes. You can send at most 20 pairs. Each key must start with a letter or underscore and contain only letters, numbers, and underscores, and cannot begin with the reserved prefixes `signalwire_`, `sw_`, `rtc_`, or `internal_` (case-insensitive). Keys are case-sensitive.
+    """)
+  @maxProperties(20)
+  @example(#{ id: "12345", case_number: "54321" })
+  custom_variables?: TypeSpec.Record<string>;
 }
 
 @doc("Request body for redacting the body of a previously sent message. Only `body` may be updated, and it must be an empty string.")

--- a/specs/signalwire-rest/message-api/messages/models/webhooks.tsp
+++ b/specs/signalwire-rest/message-api/messages/models/webhooks.tsp
@@ -50,4 +50,8 @@ model MessageStatusCallbackPayload {
   @doc("Human-readable error message if delivery failed. Null when no error occurred.")
   @example(null)
   error_message: string | null;
+
+  @doc("The same `custom_variables` key/value pairs you supplied when [sending the message](/docs/apis/rest/messages/create-message), echoed back so you can match this callback to a record in your own system. Included only when the message was sent with custom variables.")
+  @example(#{ id: "12345", case_number: "54321" })
+  custom_variables?: TypeSpec.Record<string>;
 }


### PR DESCRIPTION
## What

Documents the new `custom_variables` object on the two outbound REST endpoints, its delivery into later lifecycle events, and the new error codes.

Tracking issue: signalwire/cloud-product#18113 (rollout: production global, June 1).

REST reference is generated from TypeSpec, so the `.tsp` specs were edited and `fern/apis/signalwire-rest/openapi.yaml` regenerated; the error-codes page is hand-authored MDX.

## Changes

**`custom_variables` request parameter**
- `CallCreateParamsBase` (Call Commands — both URL and inline-SWML dial variants)
- `CreateMessageRequest` (Create Message)
- `@maxProperties(20)` enforces the 20-key limit in-schema; key format, reserved prefixes, value non-empty/≤1024-byte rules documented in prose (not expressible as schema constraints)

**Delivery of the variables**
- `MessageStatusCallbackPayload` — now includes `custom_variables` (echoed back in each status callback)
- SWML document-fetch `envs` — describes how per-call variables merge with account/project variables, with case-sensitivity/precedence rules

**Error codes** (hand-authored MDX)
- New: `must_be_object`, `too_many_custom_variables`, `invalid_custom_variable_name`, `reserved_custom_variable_name`, `invalid_custom_variable_value`, `custom_variable_value_too_long`
- New: `insufficient_balance_to_receive_message` (renamed messaging-specific code); existing `insufficient_balance` retained

**InboundCallContext accuracy fix** (surfaced while verifying the call webhook payload, not part of the feature itself)
- Added real, source-verified fields: `from_number`, `to_number` (phone calls), `dial_winner` (string `"true"`, dial winner only), `tag`, `parent`, `peer`

## Verification
- `yarn build:signalwire-rest` compiles clean; `openapi.yaml` regenerated
- All `custom_variables` locations carry `maxProperties: 20`; new call fields render and `$ref` correctly