### PR TITLE
Add status_callback to SWML send_sms method

### DIFF
--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -36350,6 +36350,11 @@ components:
           examples:
             - - notification
               - order-confirmation
+        status_callback:
+          type: string
+          description: URL to receive delivery status callbacks for the outbound message (e.g., `queued`, `sent`, `delivered`, `failed`). Not set if not specified. The callback uses the [message status callback payload](/docs/apis/rest/messages/webhooks/message-status-callback).
+          examples:
+            - https://example.com/message_status
         body:
           type: string
           description: Required if `media` is not present. The body of the SMS message.
@@ -36388,6 +36393,11 @@ components:
           examples:
             - - notification
               - order-confirmation
+        status_callback:
+          type: string
+          description: URL to receive delivery status callbacks for the outbound message (e.g., `queued`, `sent`, `delivered`, `failed`). Not set if not specified. The callback uses the [message status callback payload](/docs/apis/rest/messages/webhooks/message-status-callback).
+          examples:
+            - https://example.com/message_status
         media:
           type: array
           items:

--- a/fern/products/swml/pages/reference/methods/calling/send_sms.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/send_sms.mdx
@@ -46,6 +46,11 @@ The `send_sms` object accepts the following properties depending on the message 
 </ParamField>
 
 
+<ParamField path="send_sms.status_callback" type="string" toc={true}>
+  URL to receive delivery status callbacks for the outbound message (e.g., `queued`, `sent`, `delivered`, `failed`). Default is not set. See [Status callbacks](#status-callbacks) below.
+</ParamField>
+
+
 </Tab>
 <Tab title="MMS">
 
@@ -79,6 +84,11 @@ The `send_sms` object accepts the following properties depending on the message 
 </ParamField>
 
 
+<ParamField path="send_sms.status_callback" type="string" toc={true}>
+  URL to receive delivery status callbacks for the outbound message (e.g., `queued`, `sent`, `delivered`, `failed`). Default is not set. See [Status callbacks](#status-callbacks) below.
+</ParamField>
+
+
 </Tab>
 </Tabs>
 
@@ -87,6 +97,19 @@ The `send_sms` object accepts the following properties depending on the message 
 Set by the method:
 
 - **send_sms_result:** (out) `success` | `failed`.
+
+## **Status callbacks**
+
+When `status_callback` is set, SignalWire sends an HTTP `POST` to that URL each time the outbound
+message transitions to a new state. Callback delivery is independent of SWML execution: the document
+continues as soon as the message is accepted, and delivery-state callbacks fire afterwards.
+
+The callback uses the same payload as other outbound messages sent through SignalWire:
+
+<WebhookPayloadSnippet webhook="messageStatusCallback" />
+
+See the [Message status callback](/docs/apis/rest/messages/webhooks/message-status-callback)
+webhook page for the full field reference and the list of possible `status` values.
 
 ## **Examples**
 
@@ -159,6 +182,45 @@ sections:
             "https://example.com/image.jpg"
           ],
           "body": "Check out this image!"
+        }
+      }
+    ]
+  }
+}
+```
+</CodeBlock>
+</CodeBlocks>
+
+</Tab>
+<Tab title="Status callbacks">
+
+Send a message and receive delivery status updates at a callback URL:
+
+<CodeBlocks>
+<CodeBlock title="YAML">
+```yaml
+version: 1.0.0
+sections:
+  main:
+    - send_sms:
+        from_number: "+155512312345"
+        to_number: "+15555554321"
+        body: "Hi, I hope you're well."
+        status_callback: "https://example.com/message_status"
+```
+</CodeBlock>
+<CodeBlock title="JSON">
+```json
+{
+  "version": "1.0.0",
+  "sections": {
+    "main": [
+      {
+        "send_sms": {
+          "from_number": "+155512312345",
+          "to_number": "+15555554321",
+          "body": "Hi, I hope you're well.",
+          "status_callback": "https://example.com/message_status"
         }
       }
     ]

--- a/specs/swml/calling/Methods/send_sms/main.tsp
+++ b/specs/swml/calling/Methods/send_sms/main.tsp
@@ -21,6 +21,10 @@ model SMSBase {
   @doc("Array of tags to associate with the message to facilitate log searches.")
   @example(#["notification", "order-confirmation"])
   tags?: string[];
+
+  @doc("URL to receive delivery status callbacks for the outbound message (e.g., `queued`, `sent`, `delivered`, `failed`). Not set if not specified. The callback uses the [message status callback payload](/docs/apis/rest/messages/webhooks/message-status-callback).")
+  @example("https://example.com/message_status")
+  status_callback?: string;
 }
 
 @summary("SMS")

--- a/specs/swml/calling/tsp-output/@typespec/json-schema/SWMLObject.json
+++ b/specs/swml/calling/tsp-output/@typespec/json-schema/SWMLObject.json
@@ -4303,6 +4303,13 @@
                     ],
                     "description": "Array of tags to associate with the message to facilitate log searches."
                 },
+                "status_callback": {
+                    "type": "string",
+                    "examples": [
+                        "https://example.com/message_status"
+                    ],
+                    "description": "URL to receive delivery status callbacks for the outbound message (e.g., `queued`, `sent`, `delivered`, `failed`). Not set if not specified. The callback uses the [message status callback payload](/docs/apis/rest/messages/webhooks/message-status-callback)."
+                },
                 "body": {
                     "type": "string",
                     "examples": [
@@ -4357,6 +4364,13 @@
                         ]
                     ],
                     "description": "Array of tags to associate with the message to facilitate log searches."
+                },
+                "status_callback": {
+                    "type": "string",
+                    "examples": [
+                        "https://example.com/message_status"
+                    ],
+                    "description": "URL to receive delivery status callbacks for the outbound message (e.g., `queued`, `sent`, `delivered`, `failed`). Not set if not specified. The callback uses the [message status callback payload](/docs/apis/rest/messages/webhooks/message-status-callback)."
                 },
                 "media": {
                     "type": "array",


### PR DESCRIPTION
## What

Documents the new optional `status_callback` parameter on the SWML `send_sms` method. The parameter accepts a URL that receives message delivery status callbacks (`queued`, `sent`, `delivered`, `failed`).

## Changes

- **`specs/swml/calling/Methods/send_sms/main.tsp`** — adds `status_callback?` to the shared `SMSBase` model (applies to both SMS and MMS), with `@doc` linking to the canonical message status callback payload.
- **`fern/products/swml/pages/reference/methods/calling/send_sms.mdx`**:
  - Adds the `status_callback` `ParamField` to both the **SMS** and **MMS** tabs.
  - Adds a **Status callbacks** section using `<WebhookPayloadSnippet webhook="messageStatusCallback" />` and linking to the [Message status callback](/docs/apis/rest/messages/webhooks/message-status-callback) page — matching the pattern used by the SWML `reply` method.
  - Adds JSON + YAML examples demonstrating `status_callback`.
- Regenerated JSON Schema (`SWMLObject.json`) and OpenAPI (`openapi.yaml`) artifacts.

## Callback shape

The `send_sms` status callback uses the **same payload** as other outbound messages sent through SignalWire (the `MessageStatusCallbackPayload`), consistent with how the repo already documents the RELAY SDK and SWML `reply` status callbacks — so this links to the canonical page rather than duplicating the payload.

## Verification

- `yarn build:specs` compiles cleanly.
- `yarn fern-check` passes with 0 errors.