### PR TITLE
Fix incorrect param-combination claims on phone number search

### DIFF
--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -7885,14 +7885,14 @@ paths:
         - name: region
           in: query
           required: false
-          description: A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas. Only supported for local searches; not supported when number_type is toll-free.
+          description: A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas. Only supported for local searches; not supported when `number_type` is toll-free.
           schema:
             type: string
           explode: false
         - name: city
           in: query
           required: false
-          description: A specific City to search within. Must be used in combination with region. Only supported for local searches; not supported when number_type is toll-free.
+          description: A specific City to search within. Must be used in combination with region. Only supported for local searches; not supported when `number_type` is toll-free.
           schema:
             type: string
           explode: false

--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -7885,14 +7885,14 @@ paths:
         - name: region
           in: query
           required: false
-          description: A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas. Cannot be used in combination with areacode.
+          description: A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas.
           schema:
             type: string
           explode: false
         - name: city
           in: query
           required: false
-          description: A specific City to search within. Must be used in combination with region. Cannot be used in combination with areacode, starts_with, contains, or ends_with.
+          description: A specific City to search within. Must be used in combination with region.
           schema:
             type: string
           explode: false

--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -7885,14 +7885,14 @@ paths:
         - name: region
           in: query
           required: false
-          description: A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas.
+          description: A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas. Only supported for local searches; not supported when number_type is toll-free.
           schema:
             type: string
           explode: false
         - name: city
           in: query
           required: false
-          description: A specific City to search within. Must be used in combination with region.
+          description: A specific City to search within. Must be used in combination with region. Only supported for local searches; not supported when number_type is toll-free.
           schema:
             type: string
           explode: false

--- a/specs/signalwire-rest/relay-rest/phone-numbers/main.tsp
+++ b/specs/signalwire-rest/relay-rest/phone-numbers/main.tsp
@@ -134,11 +134,11 @@ namespace SignalWireAPI.RelayRest.PhoneNumbers {
       max_results?: int32,
 
       @query
-      @doc("A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas. Only supported for local searches; not supported when number_type is toll-free.")
+      @doc("A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas. Only supported for local searches; not supported when `number_type` is toll-free.")
       region?: string,
 
       @query
-      @doc("A specific City to search within. Must be used in combination with region. Only supported for local searches; not supported when number_type is toll-free.")
+      @doc("A specific City to search within. Must be used in combination with region. Only supported for local searches; not supported when `number_type` is toll-free.")
       city?: string,
     ): AvailablePhoneNumbersResponse | StatusCode401 | StatusCode500;
   }

--- a/specs/signalwire-rest/relay-rest/phone-numbers/main.tsp
+++ b/specs/signalwire-rest/relay-rest/phone-numbers/main.tsp
@@ -134,11 +134,11 @@ namespace SignalWireAPI.RelayRest.PhoneNumbers {
       max_results?: int32,
 
       @query
-      @doc("A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas. Cannot be used in combination with areacode.")
+      @doc("A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas.")
       region?: string,
 
       @query
-      @doc("A specific City to search within. Must be used in combination with region. Cannot be used in combination with areacode, starts_with, contains, or ends_with.")
+      @doc("A specific City to search within. Must be used in combination with region.")
       city?: string,
     ): AvailablePhoneNumbersResponse | StatusCode401 | StatusCode500;
   }

--- a/specs/signalwire-rest/relay-rest/phone-numbers/main.tsp
+++ b/specs/signalwire-rest/relay-rest/phone-numbers/main.tsp
@@ -134,11 +134,11 @@ namespace SignalWireAPI.RelayRest.PhoneNumbers {
       max_results?: int32,
 
       @query
-      @doc("A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas.")
+      @doc("A region or state to search within. Must be an ISO 3166-2 alpha-2 code, i.e. TX for Texas. Only supported for local searches; not supported when number_type is toll-free.")
       region?: string,
 
       @query
-      @doc("A specific City to search within. Must be used in combination with region.")
+      @doc("A specific City to search within. Must be used in combination with region. Only supported for local searches; not supported when number_type is toll-free.")
       city?: string,
     ): AvailablePhoneNumbersResponse | StatusCode401 | StatusCode500;
   }


### PR DESCRIPTION
Closes #382

## Problem

The Relay REST [Search Available Phone Numbers](https://signalwire.com/docs/apis/rest/phone-numbers/search-available-phone-numbers) endpoint documented combination restrictions on the `region` and `city` query params that the backend does not enforce. Requests combining `areacode` + `region` (and `areacode` + `region` + `city`) return `200 OK` with results.

## Changes

`specs/signalwire-rest/relay-rest/phone-numbers/main.tsp` (`@doc` decorators), with `fern/apis/signalwire-rest/openapi.yaml` regenerated:

- **`region`** — removed the false "Cannot be used in combination with areacode."; added that it's supported for local searches only (not toll-free).
- **`city`** — removed the unsupported "Cannot be used in combination with areacode, starts_with, contains, or ends_with." sentence; kept "Must be used in combination with region." (the one rule the backend enforces); added that it's supported for local searches only (not toll-free).

## Verification

- `yarn build:specs` regenerates `openapi.yaml`; diff limited to the two description lines.
- `yarn fern-check` passes (0 errors).
- Repo-wide grep confirms the incorrect phrasing exists nowhere else in the docs; SDK reference pages and the Compatibility API don't carry these constraints.