### PR TITLE
Fix: Allow null for hangup in SWML schema

### DIFF
--- a/specs/swml/calling/Methods/hangup/main.tsp
+++ b/specs/swml/calling/Methods/hangup/main.tsp
@@ -4,7 +4,7 @@ namespace SWML.Calling;
 model Hangup {
   @doc("End the call with an optional reason.")
   @summary("hangup")
-  hangup: {
+  hangup: null | {
     @doc("The reason for hanging up the call.")
     @example("busy")
     reason?: "hangup" | "busy" | "decline";

--- a/specs/swml/calling/tsp-output/@typespec/json-schema/SWMLObject.json
+++ b/specs/swml/calling/tsp-output/@typespec/json-schema/SWMLObject.json
@@ -580,32 +580,39 @@
             "type": "object",
             "properties": {
                 "hangup": {
-                    "type": "object",
-                    "properties": {
-                        "reason": {
-                            "anyOf": [
-                                {
-                                    "type": "string",
-                                    "const": "hangup"
-                                },
-                                {
-                                    "type": "string",
-                                    "const": "busy"
-                                },
-                                {
-                                    "type": "string",
-                                    "const": "decline"
+                    "anyOf": [
+                        {
+                            "type": "null"
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "reason": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string",
+                                            "const": "hangup"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "busy"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "const": "decline"
+                                        }
+                                    ],
+                                    "examples": [
+                                        "busy"
+                                    ],
+                                    "description": "The reason for hanging up the call."
                                 }
-                            ],
-                            "examples": [
-                                "busy"
-                            ],
-                            "description": "The reason for hanging up the call."
+                            },
+                            "unevaluatedProperties": {
+                                "not": {}
+                            }
                         }
-                    },
-                    "unevaluatedProperties": {
-                        "not": {}
-                    },
+                    ],
                     "description": "End the call with an optional reason.",
                     "title": "hangup"
                 }


### PR DESCRIPTION
Reference ticket: https://github.com/signalwire/cloud-product/issues/17670

## Description

The `hangup` in the SWML editor was showing a lint error, `incorrect type: expected object` in the dashboard SWML editor. This was because the JSON schema only accepted an object type for hangup, but since hangup takes no arguments, it should also accept null (e.g. `hangup: {}`  and `hangup: null`).

## Type of Change

- [x] Bug fix

## Changes:

- Updated the `hangup/main.tsp` to accept `null | object` for the hangup property.
- Regenerated `SWMLObject.json` which is served via CDN and used by the dashboard SWML editor for validation.

## Testing

**Note:** Testing is not straightforward since the dashboard fetches the schema from the CDN. It can be done post-deploy by checking the SWML editor no longer shows `hangup` as invalid.


