### PR TITLE
fix: correct codec type for preferredAudioCodecs and preferredVideoCodecs

### DIFF
--- a/fern/products/browser-sdk/pages/v4/reference/ClientPreferences/preferredAudioCodecs.mdx
+++ b/fern/products/browser-sdk/pages/v4/reference/ClientPreferences/preferredAudioCodecs.mdx
@@ -14,7 +14,7 @@ Preferred audio codecs in priority order.
 ## **Parameters**
 
 <ParamField path="value" type="string[]" toc={true}>
-  Ordered list of preferred audio codec MIME types.
+  Ordered list of preferred audio [codec names](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs), e.g. `["opus", "PCMU"]`.
 </ParamField>
 
 ## **Examples**

--- a/fern/products/browser-sdk/pages/v4/reference/ClientPreferences/preferredVideoCodecs.mdx
+++ b/fern/products/browser-sdk/pages/v4/reference/ClientPreferences/preferredVideoCodecs.mdx
@@ -14,7 +14,7 @@ Preferred video codecs in priority order.
 ## **Parameters**
 
 <ParamField path="value" type="string[]" toc={true}>
-  Ordered list of preferred video codec MIME types.
+  Ordered list of preferred video [codec names](https://developer.mozilla.org/en-US/docs/Web/Media/Guides/Formats/WebRTC_codecs), e.g. `["VP9", "H264"]`.
 </ParamField>
 
 ## **Examples**


### PR DESCRIPTION
## Description

correct codec type for preferredAudioCodecs and preferredVideoCodecs

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

<!-- Link any related issues: Fixes #123 or Relates to #456 -->

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [x] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
