### PR TITLE
Add `relay_conference_id` to RELAY Recordings Response 

### DIFF
--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -8541,7 +8541,7 @@ paths:
         - $ref: '#/components/parameters/RecordingPathID'
       responses:
         '200':
-          description: Recording model. A recording is associated with exactly one call leg type (PSTN, SIP, or WebRTC).
+          description: Recording model. A recording is associated with exactly one source type (PSTN, SIP, WebRTC, or Relay conference).
           content:
             application/json:
               schema:
@@ -8549,6 +8549,7 @@ paths:
                   - $ref: '#/components/schemas/PstnRecording'
                   - $ref: '#/components/schemas/SipRecording'
                   - $ref: '#/components/schemas/WebRtcRecording'
+                  - $ref: '#/components/schemas/ConferenceRecording'
         '401':
           description: Access is unauthorized.
           content:
@@ -20589,6 +20590,97 @@ components:
         - TECHNOLOGY
         - TRANSPORTATION
       description: Company vertical/industry classification.
+    ConferenceRecording:
+      type: object
+      required:
+        - id
+        - project_id
+        - created_at
+        - updated_at
+        - duration_in_seconds
+        - price
+        - price_unit
+        - status
+        - url
+        - stereo
+        - track
+        - relay_conference_id
+      properties:
+        id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: Unique ID of the recording.
+          examples:
+            - d369a402-7b43-4512-8735-9d5e1f387814
+        project_id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: Unique ID of the project.
+          examples:
+            - d369a402-7b43-4512-8735-9d5e1f387814
+        created_at:
+          type: string
+          format: date-time
+          description: Date and time when the recording was created.
+        updated_at:
+          type: string
+          format: date-time
+          description: Date and time when the recording was last updated.
+        duration_in_seconds:
+          type: integer
+          format: int32
+          description: Duration of the recording in seconds.
+          examples:
+            - 2
+        error_code:
+          type: string
+          description: Error code if the recording failed.
+        price:
+          type: number
+          format: double
+          description: Price of the recording.
+          examples:
+            - 0.05
+        price_unit:
+          type: string
+          description: Currency unit for the price.
+          examples:
+            - USD
+        status:
+          type: string
+          description: Status of the recording.
+          examples:
+            - completed
+        url:
+          type: string
+          description: URL of the recording file.
+          examples:
+            - https://example.com/recording.mp3
+        stereo:
+          type: boolean
+          description: Indicates whether the recording is stereo.
+          examples:
+            - false
+        byte_size:
+          type: integer
+          format: int32
+          description: Size of the recording file in bytes.
+          examples:
+            - 10
+        track:
+          type: string
+          description: Audio track of the recording.
+          examples:
+            - inbound
+        relay_conference_id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: Unique ID of the Relay conference the recording belongs to.
+          examples:
+            - 0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3
+      unevaluatedProperties:
+        not: {}
+      description: Recording from a Relay conference.
     ConferenceRoom:
       type: object
       required:
@@ -28063,12 +28155,6 @@ components:
           description: Unique ID of the project.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
-        relay_conference_id:
-          allOf:
-            - $ref: '#/components/schemas/uuid'
-          description: Unique ID of the Relay conference the recording belongs to, if any.
-          examples:
-            - 0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3
         created_at:
           type: string
           format: date-time
@@ -28123,6 +28209,12 @@ components:
           description: Audio track of the recording.
           examples:
             - inbound
+        relay_conference_id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: Unique ID of the Relay conference the recording belongs to, if any.
+          examples:
+            - 0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3
         relay_pstn_leg_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
@@ -28534,7 +28626,8 @@ components:
         - $ref: '#/components/schemas/PstnRecording'
         - $ref: '#/components/schemas/SipRecording'
         - $ref: '#/components/schemas/WebRtcRecording'
-      description: Recording model. A recording is associated with exactly one call leg type (PSTN, SIP, or WebRTC).
+        - $ref: '#/components/schemas/ConferenceRecording'
+      description: Recording model. A recording is associated with exactly one source type (PSTN, SIP, WebRTC, or Relay conference).
     RecordingListResponse:
       type: object
       required:
@@ -36789,6 +36882,63 @@ components:
           maximum: 1
           description: 'The similarity slider dictates how closely the AI should adhere to the original voice when attempting to replicate it. The higher the similarity, the closer the AI will sound to the original voice. IMPORTANT: Only works with ElevenLabs TTS engine.'
           default: 0.75
+        speakingRate:
+          anyOf:
+            - type: number
+            - $ref: '#/components/schemas/SWMLVar'
+          minimum: 0.5
+          maximum: 1.5
+          description: 'Adjusts how quickly the voice speaks. Values below `1.0` slow the voice down; values above `1.0` speed it up. IMPORTANT: Only works with the Inworld TTS engine.'
+          default: 1
+        temperature:
+          anyOf:
+            - type: number
+            - $ref: '#/components/schemas/SWMLVar'
+          minimum: 0
+          maximum: 2
+          description: 'Controls the randomness and expressiveness of the generated speech. Lower values produce a more consistent, predictable delivery; higher values introduce more variation. IMPORTANT: Only works with the Inworld TTS engine.'
+          default: 1
+        speed:
+          anyOf:
+            - type: number
+            - $ref: '#/components/schemas/SWMLVar'
+          minimum: 0.5
+          maximum: 2
+          description: 'How quickly the voice speaks. Values below `1.0` slow the voice down; values above `1.0` speed it up. IMPORTANT: Only works with the MiniMax TTS engine.'
+          default: 1
+        vol:
+          anyOf:
+            - type: number
+            - $ref: '#/components/schemas/SWMLVar'
+          minimum: 0.1
+          maximum: 1
+          description: 'The speaking volume. Lower values are quieter. IMPORTANT: Only works with the MiniMax TTS engine.'
+          default: 1
+        pitch:
+          anyOf:
+            - type: integer
+              format: int32
+            - $ref: '#/components/schemas/SWMLVar'
+          minimum: -12
+          maximum: 12
+          description: 'The pitch shift in semitones. Negative values lower the pitch; positive values raise it. IMPORTANT: Only works with the MiniMax TTS engine.'
+          default: 0
+        emotion:
+          type: string
+          enum:
+            - happy
+            - sad
+            - angry
+            - fearful
+            - disgusted
+            - surprised
+            - neutral
+          description: |-
+            A fixed emotional tone for the generated speech.
+            To vary the emotion automatically during a conversation, use [`languages[].emotion`](#languagesemotion) set to `auto` instead.
+            IMPORTANT: Only works with the MiniMax TTS engine.
+          examples:
+            - happy
       unevaluatedProperties:
         not: {}
       title: LanguageParams
@@ -36821,7 +36971,7 @@ components:
           type: string
           description: |-
             Voice to use for the language. String format: `<engine id>.<voice id>`.
-            Select engine from `gcloud`, `polly`, `elevenlabs`, `cartesia`, or `deepgram`.
+            Select engine from `gcloud`, `polly`, `elevenlabs`, `cartesia`, `deepgram`, `rime`, `inworld`, or `minimax`.
             For example, `gcloud.fr-FR-Neural2-B`.
           examples:
             - gcloud.fr-FR-Neural2-B
@@ -36835,9 +36985,10 @@ components:
           enum:
             - auto
           description: |-
-            Enables emotion detection for the set TTS engine. This allows the AI to express emotions when speaking.
+            Enables automatic emotion detection for the set TTS engine. This allows the AI to express emotions when speaking.
             A global emotion or specific emotions for certain topics can be set within the prompt of the AI.
-            IMPORTANT: Only works with [`Cartesia`](/docs/platform/voice/tts/cartesia) TTS engine.
+            IMPORTANT: Only works with the [`Cartesia`](/docs/platform/voice/tts/cartesia) and [`MiniMax`](/docs/platform/voice/tts/minimax) TTS engines.
+            For a fixed (non-automatic) MiniMax emotion, use [`params.emotion`](#languagesparams) instead.
           examples:
             - auto
         speed:
@@ -36906,7 +37057,7 @@ components:
           type: string
           description: |-
             Voice to use for the language. String format: `<engine id>.<voice id>`.
-            Select engine from `gcloud`, `polly`, `elevenlabs`, `cartesia`, or `deepgram`.
+            Select engine from `gcloud`, `polly`, `elevenlabs`, `cartesia`, `deepgram`, `rime`, `inworld`, or `minimax`.
             For example, `gcloud.fr-FR-Neural2-B`.
           examples:
             - gcloud.fr-FR-Neural2-B
@@ -36920,9 +37071,10 @@ components:
           enum:
             - auto
           description: |-
-            Enables emotion detection for the set TTS engine. This allows the AI to express emotions when speaking.
+            Enables automatic emotion detection for the set TTS engine. This allows the AI to express emotions when speaking.
             A global emotion or specific emotions for certain topics can be set within the prompt of the AI.
-            IMPORTANT: Only works with [`Cartesia`](/docs/platform/voice/tts/cartesia) TTS engine.
+            IMPORTANT: Only works with the [`Cartesia`](/docs/platform/voice/tts/cartesia) and [`MiniMax`](/docs/platform/voice/tts/minimax) TTS engines.
+            For a fixed (non-automatic) MiniMax emotion, use [`params.emotion`](#languagesparams) instead.
           examples:
             - auto
         speed:
@@ -42553,12 +42705,6 @@ components:
           description: Unique ID of the project.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
-        relay_conference_id:
-          allOf:
-            - $ref: '#/components/schemas/uuid'
-          description: Unique ID of the Relay conference the recording belongs to, if any.
-          examples:
-            - 0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3
         created_at:
           type: string
           format: date-time
@@ -42613,6 +42759,12 @@ components:
           description: Audio track of the recording.
           examples:
             - inbound
+        relay_conference_id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: Unique ID of the Relay conference the recording belongs to, if any.
+          examples:
+            - 0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3
         relay_sip_leg_id:
           allOf:
             - $ref: '#/components/schemas/uuid'
@@ -48011,12 +48163,6 @@ components:
           description: Unique ID of the project.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
-        relay_conference_id:
-          allOf:
-            - $ref: '#/components/schemas/uuid'
-          description: Unique ID of the Relay conference the recording belongs to, if any.
-          examples:
-            - 0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3
         created_at:
           type: string
           format: date-time
@@ -48071,6 +48217,12 @@ components:
           description: Audio track of the recording.
           examples:
             - inbound
+        relay_conference_id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: Unique ID of the Relay conference the recording belongs to, if any.
+          examples:
+            - 0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3
         relay_webrtc_leg_id:
           allOf:
             - $ref: '#/components/schemas/uuid'

--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -28063,6 +28063,12 @@ components:
           description: Unique ID of the project.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
+        relay_conference_id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: Unique ID of the Relay conference the recording belongs to, if any.
+          examples:
+            - 0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3
         created_at:
           type: string
           format: date-time
@@ -42547,6 +42553,12 @@ components:
           description: Unique ID of the project.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
+        relay_conference_id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: Unique ID of the Relay conference the recording belongs to, if any.
+          examples:
+            - 0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3
         created_at:
           type: string
           format: date-time
@@ -47999,6 +48011,12 @@ components:
           description: Unique ID of the project.
           examples:
             - d369a402-7b43-4512-8735-9d5e1f387814
+        relay_conference_id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: Unique ID of the Relay conference the recording belongs to, if any.
+          examples:
+            - 0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3
         created_at:
           type: string
           format: date-time

--- a/specs/signalwire-rest/relay-rest/recordings/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/recordings/models/core.tsp
@@ -20,6 +20,10 @@ model RecordingBase {
   @example("d369a402-7b43-4512-8735-9d5e1f387814")
   project_id: uuid;
 
+  @doc("Unique ID of the Relay conference the recording belongs to, if any.")
+  @example("0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3")
+  relay_conference_id?: uuid;
+
   @doc("Date and time when the recording was created.")
   created_at: utcDateTime;
 

--- a/specs/signalwire-rest/relay-rest/recordings/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/recordings/models/core.tsp
@@ -20,10 +20,6 @@ model RecordingBase {
   @example("d369a402-7b43-4512-8735-9d5e1f387814")
   project_id: uuid;
 
-  @doc("Unique ID of the Relay conference the recording belongs to, if any.")
-  @example("0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3")
-  relay_conference_id?: uuid;
-
   @doc("Date and time when the recording was created.")
   created_at: utcDateTime;
 
@@ -70,6 +66,10 @@ model RecordingBase {
 model PstnRecording {
   ...RecordingBase;
 
+  @doc("Unique ID of the Relay conference the recording belongs to, if any.")
+  @example("0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3")
+  relay_conference_id?: uuid;
+
   @doc("ID of the PSTN leg associated with the recording.")
   relay_pstn_leg_id: uuid;
 }
@@ -77,6 +77,10 @@ model PstnRecording {
 @doc("Recording from a SIP call leg.")
 model SipRecording {
   ...RecordingBase;
+
+  @doc("Unique ID of the Relay conference the recording belongs to, if any.")
+  @example("0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3")
+  relay_conference_id?: uuid;
 
   @doc("ID of the SIP leg associated with the recording.")
   relay_sip_leg_id: uuid;
@@ -86,13 +90,27 @@ model SipRecording {
 model WebRtcRecording {
   ...RecordingBase;
 
+  @doc("Unique ID of the Relay conference the recording belongs to, if any.")
+  @example("0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3")
+  relay_conference_id?: uuid;
+
   @doc("ID of the WebRTC leg associated with the recording.")
   relay_webrtc_leg_id: uuid;
 }
 
-@doc("Recording model. A recording is associated with exactly one call leg type (PSTN, SIP, or WebRTC).")
+@doc("Recording from a Relay conference.")
+model ConferenceRecording {
+  ...RecordingBase;
+
+  @doc("Unique ID of the Relay conference the recording belongs to.")
+  @example("0089cc48-4f98-4a6b-90d8-61f8a5d1b0e3")
+  relay_conference_id: uuid;
+}
+
+@doc("Recording model. A recording is associated with exactly one source type (PSTN, SIP, WebRTC, or Relay conference).")
 union Recording {
   pstn: PstnRecording,
   sip: SipRecording,
   webrtc: WebRtcRecording,
+  conference: ConferenceRecording,
 }


### PR DESCRIPTION
## Description
This PR adds the optional `relay_conference_id` to the serialized response from the `api/relay/rest/recordings` endpoint. This field is only present if the recording belongs to a RELAY/SWML Conference.

## Type of Change

- [x] New feature

## Related Issues

https://github.com/signalwire/cloud-product/issues/19111

## Testing
Tested manually by ensuring that list recordings/show recording both show the relay conference ID if one exists.

**List Recordings**
(scrubbed UUIDs)

```
curl --location 'https://SPACE.signalwire.com/api/relay/rest/recordings' \
--header 'Authorization: Basic '
```

```
{
    "links": {
        "self": "/api/relay/rest/recordings?page_number=0&page_size=50",
        "first": "/api/relay/rest/recordings?page_size=50"
    },
    "data": [
        {
            "id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
            "project_id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
            "relay_conference_id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
            "created_at": "Wed, 17 Jun 2026 16:25:14 +0000",
            "updated_at": "Wed, 17 Jun 2026 16:25:23 +0000",
            "duration_in_seconds": 4,
            "error_code": null,
            "price": 0.0,
            "price_unit": "USD",
            "status": "finished",
            "url": "/api/relay/rest/recordings/2d7333d1-dff4-4000-8353-a2e3540d2227",
            "stereo": false,
            "byte_size": 71084,
            "track": "both"
        },
        {
            "id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
            "project_id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
            "relay_pstn_leg_id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
            "created_at": "Thu, 15 Jan 2026 22:48:38 +0000",
            "updated_at": "Thu, 15 Jan 2026 22:49:47 +0000",
            "duration_in_seconds": 69,
            "error_code": null,
            "price": 0.0,
            "price_unit": "USD",
            "status": "finished",
            "url": "/api/relay/rest/recordings/2d7333d1-dff4-4000-8353-a2e3540d2227",
            "stereo": false,
            "byte_size": 135168,
            "track": "both"
        },
        {
            "id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
            "project_id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
            "relay_sip_leg_id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
            "created_at": "Thu, 22 May 2025 19:52:28 +0000",
            "updated_at": "Thu, 22 May 2025 19:52:36 +0000",
            "duration_in_seconds": 7,
            "error_code": null,
            "price": 0.0,
            "price_unit": "USD",
            "status": "finished",
            "url": "/api/relay/rest/recordings/2d7333d1-dff4-4000-8353-a2e3540d2227",
            "stereo": false,
            "byte_size": 94208,
            "track": "both"
        },
    ]
}
```

**Retrieve Recording**

```
curl --location 'https://SPACE.signalwire.com/api/relay/rest/recordings/2d7333d1-dff4-4000-8353-a2e3540d2227' \
--header 'Authorization: Basic '
```

```
{
    "id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
    "project_id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
    "relay_conference_id": "2d7333d1-dff4-4000-8353-a2e3540d2227",
    "created_at": "Wed, 17 Jun 2026 16:25:14 +0000",
    "updated_at": "Wed, 17 Jun 2026 16:25:23 +0000",
    "duration_in_seconds": 4,
    "error_code": null,
    "price": 0.0,
    "price_unit": "USD",
    "status": "finished",
    "url": "/api/relay/rest/recordings/2d7333d1-dff4-4000-8353-a2e3540d2227",
    "stereo": false,
    "byte_size": 71084,
    "track": "both"
}
```

## Screenshots 
<img width="1145" height="672" alt="Screenshot 2026-06-17 at 12 23 36 PM" src="https://github.com/user-attachments/assets/526c7be6-7105-4c46-85a3-0a410b7af401" />

<img width="755" height="1318" alt="Screenshot 2026-06-17 at 12 23 48 PM" src="https://github.com/user-attachments/assets/e14b2423-27c5-4951-b2a7-a50ec9047529" />

