### PR TITLE
`chat/overview.mdx`: remove reference to DialogFlow

### DIFF
--- a/fern/products/platform/pages/messaging/chat/overview.mdx
+++ b/fern/products/platform/pages/messaging/chat/overview.mdx
@@ -83,10 +83,6 @@ You can create channels, members can subscribe to those channels, and they can s
     While Chat does not support sending/receiving via SMS by default, using RELAY Realtime SDK along with our [Messaging API](/docs/platform/messaging) you can add SMS support (or any other format of communication) to it!
   </Accordion>
 
-  <Accordion title="Can we use Chat to build a chatbot?">
-    Yes! You can use Chat along with [Dialogflow](https://cloud.google.com/dialogflow#chatbots-for-b2c-conversations) to create chatbots according to your needs.
-  </Accordion>
-
   <Accordion title="Can Chat messages be logged?">
     Using the [SDK's Chat API](/docs/server-sdks/reference/python/rest/chat) you can listen for the "message" event and log each message accordingly.
   </Accordion>


### PR DESCRIPTION
## Description

Remove a reference to the deprecated DialogFlow integration in the Platform > Chat overview page

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code cleanup / refactor