### PR TITLE
Improve discoverability for geo-restriction error messages

### DIFF
--- a/fern/products/apis/pages/core/error-codes.mdx
+++ b/fern/products/apis/pages/core/error-codes.mdx
@@ -803,7 +803,7 @@ The `code` field above maps to one of the values below. Each entry describes the
 
 <ParamField path="not_routable" type="Error" toc={true}>
 
-- Unable to locate a route to the destination number. Please check geographic permissions and the destination number, and contact Support if issues persist.
+- Unable to locate a route to the destination number. Please check [geographic permissions](/docs/platform/how-to-enable-international-services) and the destination number, and contact Support if issues persist.
 </ParamField>
 
 <ParamField path="not_routeable" type="Error" toc={true}>

--- a/fern/products/platform/pages/platform/core/how-to-enable-international-outbound-dialing-sms.mdx
+++ b/fern/products/platform/pages/platform/core/how-to-enable-international-outbound-dialing-sms.mdx
@@ -83,3 +83,12 @@ Please Note: Messaging can only be sent from US and Canadian (CA) long code numb
 International SMS is not enabled for toll-free numbers.
 
 </Warning>
+
+## Troubleshooting
+
+If you attempt to call or message a destination in a country you have not enabled, the request
+fails because no route to that destination is permitted by your account. REST requests return the
+[`not_routable`](/docs/apis/error-codes#not_routable) error code.
+
+To resolve it, confirm International Services are active on your Space and that the destination
+country is checked under **Geographic Permissions**, following the steps above.


### PR DESCRIPTION
## Description

Minor, prose-only change. 

Follow-up to https://github.com/signalwire/cloud-product/issues/19010, which improved the generic error message previously returned when a call failed due to geographic restrictions on the account.

- **`error-codes.mdx`** — linked the existing "geographic permissions" text in `not_routable` to the International services guide.
- **International services guide** — added a Troubleshooting section connecting geo-restricted call/SMS failures to the `not_routable` code and the Geographic Permissions setting.

The two pages also now cross-link.

---

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

https://github.com/signalwire/cloud-product/issues/19010

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [x] All existing tests pass
