### PR TITLE
Add New Error Code -> Message Pairs for RELAY Messages

### DIFF
--- a/fern/products/apis/pages/core/error-codes.mdx
+++ b/fern/products/apis/pages/core/error-codes.mdx
@@ -86,6 +86,16 @@ The `code` field above maps to one of the values below. Each entry describes the
 - The address has no valid channels.
 </ParamField>
 
+<ParamField path="associated_campaign_inactive" type="Error" toc={true}>
+
+- The carrier flagged the A2P 10DLC campaign associated with this number as inactive, so the message was not delivered. Verify the campaign's status in your dashboard and contact Support if it should be active.
+</ParamField>
+
+<ParamField path="associated_campaign_suspended" type="Error" toc={true}>
+
+- The carrier flagged the A2P 10DLC campaign associated with this number as suspended, so the message was not delivered. Review the campaign's compliance status and contact Support for help resolving the suspension.
+</ParamField>
+
 <ParamField path="auto_top_up_deactivated" type="Error" toc={true}>
 
 - Auto top-up is not active on this account.
@@ -151,6 +161,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 - The campaign ID provided could not be found.
 </ParamField>
 
+<ParamField path="campaign_throughput_exceeded" type="Error" toc={true}>
+
+- The message exceeded the throughput (messages-per-second) limit the carrier allows for this US A2P 10DLC campaign. Slow your send rate or request a higher throughput tier, then retry.
+</ParamField>
+
 <ParamField path="cannot_cancel_in_progress" type="Error" toc={true}>
 
 - Cannot cancel an in-progress call.
@@ -179,6 +194,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 <ParamField path="cannot_update_completed" type="Error" toc={true}>
 
 - Completed calls cannot be updated.
+</ParamField>
+
+<ParamField path="carrier_violation" type="Error" toc={true}>
+
+- The carrier flagged the message as spam and did not deliver it. Review the message content for spam-like patterns and confirm the sending number is registered to an approved campaign.
 </ParamField>
 
 <ParamField path="channel_has_missing_properties" type="Error" toc={true}>
@@ -346,9 +366,19 @@ The `code` field above maps to one of the values below. Each entry describes the
 - The account has an insufficient balance to receive the message.
 </ParamField>
 
+<ParamField path="insufficient_balance_to_send_message" type="Error" toc={true}>
+
+- The account does not have enough balance to send the message. Add funds or enable auto top-up, then retry.
+</ParamField>
+
 <ParamField path="integration_test_verified_caller_required" type="Error" toc={true}>
 
 - The `to` number must be the verified caller ID for the trial campaign.
+</ParamField>
+
+<ParamField path="internal_error_occurred" type="Error" toc={true}>
+
+- An internal error occurred while processing the message. This is a temporary server-side issue — retry with backoff, and contact Support if it persists.
 </ParamField>
 
 <ParamField path="invalid_addresses_for_transfer_skill" type="Error" toc={true}>
@@ -566,6 +596,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 - The subproject ID passed could not be found or does not belong to the project being used to authenticate the request.
 </ParamField>
 
+<ParamField path="invalid_to_number" type="Error" toc={true}>
+
+- The destination number for the message is invalid. Check the format and location, or reach out to Support if issues persist.
+</ParamField>
+
 <ParamField path="invalid_token_format" type="Error" toc={true}>
 
 - The format of the provided token is invalid.
@@ -596,9 +631,34 @@ The `code` field above maps to one of the values below. Each entry describes the
 - has exceeded the maximum number of queued messages/calls for this number
 </ParamField>
 
+<ParamField path="media_connection_timeout" type="Error" toc={true}>
+
+- The connection to the media URL timed out before the file could be retrieved. Verify the URL is reachable and responds promptly, then retry.
+</ParamField>
+
+<ParamField path="media_download_failed" type="Error" toc={true}>
+
+- The media file could not be downloaded from the provided URL (for example, the resource was not found). Verify the URL points to a valid, publicly accessible file and retry.
+</ParamField>
+
+<ParamField path="media_exceeds_size_limit" type="Error" toc={true}>
+
+- The media file exceeds the maximum allowed size. Reduce the file size or host a smaller version, then retry.
+</ParamField>
+
 <ParamField path="media_limit_exceeded" type="Error" toc={true}>
 
 - Exceeded the maximum number of media items allowed per message (currently 8).
+</ParamField>
+
+<ParamField path="media_processing_failed" type="Error" toc={true}>
+
+- The media could not be processed (for example, too many redirects or an internal processing error). Verify the media URL serves the file directly and retry.
+</ParamField>
+
+<ParamField path="media_request_failed" type="Error" toc={true}>
+
+- The media URL returned an error during retrieval (for example, an SSL or HTTP error). Verify the URL is valid and serves the media over HTTPS, then retry.
 </ParamField>
 
 <ParamField path="media_size_exceeds_limit" type="Error" toc={true}>
@@ -616,14 +676,34 @@ The `code` field above maps to one of the values below. Each entry describes the
 - The project's messaging backlog limit has been exceeded. Wait before sending more messages.
 </ParamField>
 
+<ParamField path="message_blocked_by_carrier" type="Error" toc={true}>
+
+- The carrier blocked the message — for example, because the recipient has opted out. Confirm the recipient has consented to receive messages before retrying.
+</ParamField>
+
+<ParamField path="message_blocked_by_number" type="Error" toc={true}>
+
+- The destination number blocked messages from the sending number. No further messages can be delivered to this recipient from this number.
+</ParamField>
+
 <ParamField path="message_body_required" type="Error" toc={true}>
 
 - The message body is required.
 </ParamField>
 
+<ParamField path="message_filtered" type="Error" toc={true}>
+
+- Message Filtered. SignalWire's spam filter blocked the message. Distinct from `carrier_violation`, which is a carrier determination.
+</ParamField>
+
 <ParamField path="message_length_exceeds_limit" type="Error" toc={true}>
 
 - The message length exceeds the allowed limit.
+</ParamField>
+
+<ParamField path="message_validity_period_expired_at_carrier" type="Error" toc={true}>
+
+- The message's validity period expired at the carrier before it could be delivered — for example, the handset was unreachable for too long. Retry when the recipient is likely available.
 </ParamField>
 
 <ParamField path="messaging_provider_invalid" type="Error" toc={true}>
@@ -901,6 +981,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 - The rate limit has been exceeded.
 </ParamField>
 
+<ParamField path="rejected_by_receiving_carrier_for_unspecified_reason" type="Error" toc={true}>
+
+- The receiving carrier rejected the message without providing a specific reason. Retry later, and contact Support if the issue persists.
+</ParamField>
+
 <ParamField path="reserved_custom_variable_name" type="Error" toc={true}>
 
 - A `custom_variables` key uses a reserved prefix. The prefixes `signalwire_`, `sw_`, `rtc_`, and `internal_` are reserved for internal use and cannot be used in your own keys.
@@ -961,6 +1046,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 - The provided send_as number is missing or invalid.
 </ParamField>
 
+<ParamField path="sending_disabled_for_space" type="Error" toc={true}>
+
+- Outbound messaging is disabled for this Space. Contact Support to enable messaging for your Space.
+</ParamField>
+
 <ParamField path="sending_restricted_to_verified" type="Error" toc={true}>
 
 - Sending is restricted to verified numbers for this account.
@@ -994,6 +1084,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 <ParamField path="terms_and_conditions_required" type="Error" toc={true}>
 
 - You must agree to the terms and conditions to complete registration.
+</ParamField>
+
+<ParamField path="tmobile_daily_limit_reached" type="Error" toc={true}>
+
+- The US A2P 10DLC campaign reached its T-Mobile daily message limit. Messages to T-Mobile recipients resume the next day.
 </ParamField>
 
 <ParamField path="to_destination_unresolvable" type="Error" toc={true}>
@@ -1051,9 +1146,29 @@ The `code` field above maps to one of the values below. Each entry describes the
 - This account has had too many Verified Caller ID requests within a short timeframe. As a precaution, we have disabled creating more for a short time. Please contact support if you need this restriction lifted sooner.
 </ParamField>
 
+<ParamField path="unable_to_deliver_to_carrier" type="Error" toc={true}>
+
+- The message could not be handed off to the carrier. This is typically a temporary issue — retry with backoff, and contact Support if it persists.
+</ParamField>
+
+<ParamField path="unknown_destination_handset" type="Error" toc={true}>
+
+- The message could not be routed to the destination handset because the number is unknown or unreachable. Verify the destination number and its format.
+</ParamField>
+
 <ParamField path="unknown_download_error" type="Error" toc={true}>
 
 - An unexpected error occurred while downloading the file. Please try again later or contact support if the issue persists.
+</ParamField>
+
+<ParamField path="unknown_error" type="Error" toc={true}>
+
+- The delivery failed at the carrier level for an unspecified reason. Retry, and contact Support if the issue persists.
+</ParamField>
+
+<ParamField path="unreachable_destination_handset" type="Error" toc={true}>
+
+- The destination handset could not be reached — it may be busy, offline, not SMS-capable, or have full storage. This is often temporary, so retry later.
 </ParamField>
 
 <ParamField path="unrecognized_fabric_addresses" type="Error" toc={true}>
@@ -1061,9 +1176,24 @@ The `code` field above maps to one of the values below. Each entry describes the
 - One or more of the provided fabric addresses is unrecognized. Check that all IDs are valid and belong to the current project.
 </ParamField>
 
+<ParamField path="unrouteable_message" type="Error" toc={true}>
+
+- The outbound message could not be routed to a destination. Verify the destination number and your project's [geographic permissions](/docs/platform/how-to-enable-international-services).
+</ParamField>
+
+<ParamField path="unrouteable_message_received" type="Error" toc={true}>
+
+- An inbound message could not be routed to a destination in your project. Verify that the receiving number is configured with a handler for inbound messages.
+</ParamField>
+
 <ParamField path="unsupported_file_extension" type="Error" toc={true}>
 
 - Unsupported file extension.
+</ParamField>
+
+<ParamField path="unsupported_media_type" type="Error" toc={true}>
+
+- The media content type `%{content_type}` is not supported. Use a supported media format and retry.
 </ParamField>
 
 <ParamField path="unsupported_mode" type="Error" toc={true}>


### PR DESCRIPTION
## Description
We are working on improving the RELAY messaging error interface so customers with failing messages see consistent and reliable errors. Part of this process included working with our Carrier team to ensure that errors from upstream providers are correctly mapped to useful error codes that help the customer understand what went wrong.

This PR adds the new error code/message pairs to the SW REST error codes. It blocks deployment of the subsequent application work as we don't want to return new codes until they are fully documented.

## Related Issues
references https://github.com/signalwire/cloud-product/issues/19421, required for https://github.com/signalwire/prime-rails/pull/9315

## Testing
I ran the server locally and verified that the new codes were showing up: 

<img width="852" height="407" alt="Screenshot 2026-07-07 at 10 40 08 AM" src="https://github.com/user-attachments/assets/6a4536ab-9424-4f4a-be96-e67661a43c9c" />
