### PR TITLE
Improve SWML homepage discoverability in Fern Search

### DIFF
--- a/fern/products/swml/pages/get-started/index.mdx
+++ b/fern/products/swml/pages/get-started/index.mdx
@@ -2,6 +2,8 @@
 id: 35610872-2be6-4e59-9819-ff57a18b5181
 title: Introduction to SWML
 subtitle: Build powerful communication applications with the SignalWire Markup Language
+headline: SWML | SignalWire Markup Language
+keywords: SWML, SignalWire Markup Language, Voice, Messaging, Calling, Script
 description: Get started with SWML (SignalWire Markup Language), a markup and scripting language for quickly writing powerful communication applications in YAML or JSON documents.
 slug: /
 max-toc-depth: 3

--- a/fern/products/swml/pages/get-started/index.mdx
+++ b/fern/products/swml/pages/get-started/index.mdx
@@ -3,7 +3,7 @@ id: 35610872-2be6-4e59-9819-ff57a18b5181
 title: Introduction to SWML
 subtitle: Build powerful communication applications with the SignalWire Markup Language
 headline: SWML | SignalWire Markup Language
-keywords: SWML, SignalWire Markup Language, Voice, Messaging, Calling, Script
+keywords: SWML, SignalWire Markup Language, Voice, Messaging, Calling, AI, Script, Dialplan
 description: Get started with SWML (SignalWire Markup Language), a markup and scripting language for quickly writing powerful communication applications in YAML or JSON documents.
 slug: /
 max-toc-depth: 3


### PR DESCRIPTION
## Description

Add `headline` and `keywords` front matter items. This should cause Algolia to rank the SWML intro page higher in direct search. `keywords` is the top priority search attribute, followed by `title`. (`headline` is basically `title` but for search engines.)

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

may help with #457

## Testing

Cannot be tested except in production

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass
