### PR TITLE
Add new project management endpoints and error codes

### DIFF
--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -31,6 +31,11 @@ tags:
     externalDocs:
       url: https://signalwire.com/docs/apis
       description: Developer documentation on SignalWire REST APIs
+  - name: Projects
+    description: Manage projects and subprojects under the authenticated root project.
+    externalDocs:
+      url: https://signalwire.com/docs/apis
+      description: Developer documentation on SignalWire REST APIs
   - name: Project Tokens
     description: Manage API tokens for authentication.
     externalDocs:
@@ -6435,6 +6440,293 @@ paths:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
       tags:
         - Project Tokens
+  /api/projects:
+    get:
+      operationId: list_projects
+      summary: List projects
+      description: |-
+        Lists the authenticated root project and its subprojects.
+
+        All endpoints operate only within the caller's project tree — the authenticated root
+        project and the subprojects beneath it.
+
+        #### Permissions
+
+        The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Management_.
+
+        [Learn more about API scopes](/docs/platform/your-signalwire-api-space).
+      parameters:
+        - $ref: '#/components/parameters/Projects.ListProjectsQuery.name'
+        - $ref: '#/components/parameters/Projects.ListProjectsQuery.page_size'
+        - $ref: '#/components/parameters/Projects.ListProjectsQuery.page_token'
+        - $ref: '#/components/parameters/Projects.ListProjectsQuery.page_number'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Projects.ProjectListResponse'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
+      tags:
+        - Projects
+    post:
+      operationId: create_subproject
+      summary: Create a subproject
+      description: |-
+        Creates a subproject under the authenticated root project.
+
+        Creating a project is only allowed when authenticated as a top-level (root) project.
+        A subproject cannot itself contain subprojects, so attempting to create one while
+        authenticated as a subproject fails with `422 nested_subprojects_not_allowed`.
+
+        The response includes the `signing_key`. This is the only time it is returned — it
+        cannot be retrieved through the API afterward, so capture it from this response.
+
+        #### Permissions
+
+        The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Management_.
+
+        [Learn more about API scopes](/docs/platform/your-signalwire-api-space).
+      parameters: []
+      responses:
+        '201':
+          description: The request has succeeded and a new resource has been created as a result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Projects.ProjectWithSigningKey'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
+        '422':
+          description: |-
+            The request could not be processed. When creating a project while authenticated as a
+            subproject, the response includes the `nested_subprojects_not_allowed` code. A blank or
+            overly long `name` returns a standard validation error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Projects.CreateProjectStatusCode422'
+      tags:
+        - Projects
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Projects.CreateProjectRequest'
+  /api/projects/{id}:
+    get:
+      operationId: get_project
+      summary: Retrieve a project
+      description: |-
+        Retrieves a single project or subproject.
+
+        A project ID outside the caller's project tree returns `404 Not Found`.
+
+        #### Permissions
+
+        The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Management_.
+
+        [Learn more about API scopes](/docs/platform/your-signalwire-api-space).
+      parameters:
+        - $ref: '#/components/parameters/Projects.ProjectPathID'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Projects.ProjectResponse'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode404'
+      tags:
+        - Projects
+    patch:
+      operationId: update_project
+      summary: Update a project
+      description: |-
+        Updates a project's name and settings.
+
+        #### Permissions
+
+        The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Management_.
+
+        [Learn more about API scopes](/docs/platform/your-signalwire-api-space).
+      parameters:
+        - $ref: '#/components/parameters/Projects.ProjectPathID'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Projects.ProjectResponse'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode404'
+        '422':
+          description: The request failed validation, for example a blank or overly long `name`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Projects.UpdateProjectStatusCode422'
+      tags:
+        - Projects
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Projects.UpdateProjectRequest'
+    delete:
+      operationId: delete_subproject
+      summary: Delete a subproject
+      description: |-
+        Deletes a subproject.
+
+        Only subprojects can be deleted through this API. Deleting the root/parent project
+        returns `422 only_subprojects_can_be_deleted`. A project must have no phone numbers
+        before it can be deleted; otherwise the request returns `422 phone_numbers_must_be_removed`.
+
+        On a successful delete, the subproject's registry brands and campaigns are migrated up
+        to the parent project.
+
+        #### Permissions
+
+        The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Management_.
+
+        [Learn more about API scopes](/docs/platform/your-signalwire-api-space).
+      parameters:
+        - $ref: '#/components/parameters/Projects.ProjectPathID'
+      responses:
+        '204':
+          description: 'There is no content to send for this request, but the headers may be useful. '
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode404'
+        '422':
+          description: |-
+            The request could not be processed. Deleting a root/parent project returns
+            `only_subprojects_can_be_deleted`, and deleting a project that still has phone numbers
+            assigned returns `phone_numbers_must_be_removed`.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Projects.DeleteProjectStatusCode422'
+      tags:
+        - Projects
+  /api/projects/{id}/signing-key/rotate:
+    post:
+      operationId: rotate_signing_key
+      summary: Rotate a project's signing key
+      description: |-
+        Rotates the project's signing key and returns the project with the new `signing_key`.
+
+        The previous key may take about 1–2 minutes to stop working. As with create, the
+        `signing_key` is only returned on this response and cannot be retrieved afterward.
+
+        #### Permissions
+
+        The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Management_.
+
+        [Learn more about API scopes](/docs/platform/your-signalwire-api-space).
+      parameters:
+        - $ref: '#/components/parameters/Projects.ProjectPathID'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Projects.ProjectWithSigningKey'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
+        '403':
+          description: Access is forbidden.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode404'
+      tags:
+        - Projects
   /api/pubsub/tokens:
     post:
       operationId: create_token
@@ -12434,6 +12726,52 @@ components:
       in: path
       required: true
       description: The unique identifier of the Resource.
+      schema:
+        $ref: '#/components/schemas/uuid'
+    Projects.ListProjectsQuery.name:
+      name: name
+      in: query
+      required: false
+      description: Filter projects by name.
+      schema:
+        type: string
+      explode: false
+    Projects.ListProjectsQuery.page_number:
+      name: page_number
+      in: query
+      required: false
+      description: The page index, used together with `page_token`.
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+        default: 0
+      explode: false
+    Projects.ListProjectsQuery.page_size:
+      name: page_size
+      in: query
+      required: false
+      description: The number of results per page.
+      schema:
+        type: integer
+        format: int32
+        minimum: 1
+        maximum: 1000
+        default: 50
+      explode: false
+    Projects.ListProjectsQuery.page_token:
+      name: page_token
+      in: query
+      required: false
+      description: Cursor token for paging, taken from the `links` in a previous response.
+      schema:
+        type: string
+      explode: false
+    Projects.ProjectPathID:
+      name: id
+      in: path
+      required: true
+      description: The unique identifier of the project or subproject.
       schema:
         $ref: '#/components/schemas/uuid'
     QueueIdPath:
@@ -28131,6 +28469,440 @@ components:
       unevaluatedProperties:
         not: {}
       description: Request body for updating an API Token.
+    Projects.CreateProjectRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          maxLength: 250
+          description: The name of the subproject.
+          examples:
+            - Acme Staging
+        protect_recordings:
+          type: boolean
+          description: When enabled, recordings created within the project require authentication to access.
+          examples:
+            - true
+        protect_message_media:
+          type: boolean
+          description: When enabled, message media created within the project requires authentication to access.
+          examples:
+            - false
+        protect_fax_media:
+          type: boolean
+          description: When enabled, fax media created within the project requires authentication to access.
+          examples:
+            - false
+        force_https_requests:
+          type: boolean
+          description: When enabled, requests made to the project's webhooks and callbacks must use HTTPS.
+          examples:
+            - true
+      unevaluatedProperties:
+        not: {}
+      description: Request body for creating a subproject.
+    Projects.CreateProjectStatusCode422:
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Types.StatusCodes.RestApiErrorItem'
+          description: List of validation errors.
+      unevaluatedProperties:
+        not: {}
+      description: |-
+        The request could not be processed. When creating a project while authenticated as a
+        subproject, the response includes the `nested_subprojects_not_allowed` code. A blank or
+        overly long `name` returns a standard validation error.
+      examples:
+        - statusCode: 422
+          errors:
+            - type: validation_error
+              code: nested_subprojects_not_allowed
+              message: Subprojects can only be created under a top-level project.
+              attribute: null
+              url: https://signalwire.com/docs/apis/error-codes#nested_subprojects_not_allowed
+    Projects.DeleteProjectStatusCode422:
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Types.StatusCodes.RestApiErrorItem'
+          description: List of validation errors.
+      unevaluatedProperties:
+        not: {}
+      description: |-
+        The request could not be processed. Deleting a root/parent project returns
+        `only_subprojects_can_be_deleted`, and deleting a project that still has phone numbers
+        assigned returns `phone_numbers_must_be_removed`.
+      examples:
+        - statusCode: 422
+          errors:
+            - type: validation_error
+              code: phone_numbers_must_be_removed
+              message: All phone numbers must be removed from the project before it can be deleted.
+              attribute: null
+              url: https://signalwire.com/docs/apis/error-codes#phone_numbers_must_be_removed
+    Projects.Project:
+      type: object
+      required:
+        - id
+        - name
+        - parent_project_id
+        - subproject
+        - region_preference
+        - protect_recordings
+        - protect_message_media
+        - protect_fax_media
+        - force_https_requests
+        - created_at
+        - updated_at
+      properties:
+        id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: The unique identifier of the project.
+          examples:
+            - 8f14e45f-ceea-467d-9c2b-7a1d3a9b2c34
+        name:
+          type: string
+          description: The name of the project.
+          examples:
+            - Acme Staging
+        parent_project_id:
+          anyOf:
+            - $ref: '#/components/schemas/uuid'
+            - type: 'null'
+          description: The unique identifier of the root project. `null` when this project is itself a root project.
+          examples:
+            - b3877739-5c7e-4d4f-9d1a-2f0c8c2f1a11
+        subproject:
+          type: boolean
+          description: '`true` when this project is a subproject.'
+          examples:
+            - true
+        region_preference:
+          type: string
+          description: The effective region preference for the project. Returned in all responses; it is not currently settable through this API.
+          examples:
+            - us-west
+        protect_recordings:
+          type: boolean
+          description: When enabled, recordings created within the project require authentication to access.
+          examples:
+            - false
+        protect_message_media:
+          type: boolean
+          description: When enabled, message media created within the project requires authentication to access.
+          examples:
+            - false
+        protect_fax_media:
+          type: boolean
+          description: When enabled, fax media created within the project requires authentication to access.
+          examples:
+            - false
+        force_https_requests:
+          type: boolean
+          description: When enabled, requests made to the project's webhooks and callbacks must use HTTPS.
+          examples:
+            - true
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time when the project was created.
+          examples:
+            - '2024-05-06T12:20:00Z'
+        updated_at:
+          type: string
+          format: date-time
+          description: The date and time when the project was last updated.
+          examples:
+            - '2024-05-06T12:20:00Z'
+      unevaluatedProperties:
+        not: {}
+      description: A project or subproject within the caller's project tree.
+      title: Project
+    Projects.ProjectListResponse:
+      type: object
+      required:
+        - links
+        - data
+      properties:
+        links:
+          allOf:
+            - $ref: '#/components/schemas/Projects.ProjectPaginationLinks'
+          description: Pagination links for the list of projects.
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/Projects.Project'
+          description: The projects on this page.
+      unevaluatedProperties:
+        not: {}
+      description: A page of projects.
+    Projects.ProjectPaginationLinks:
+      type: object
+      required:
+        - self
+        - first
+      properties:
+        self:
+          type: string
+          format: uri
+          description: The link to the current page.
+          examples:
+            - https://example-space.signalwire.com/api/projects?page_size=50
+        first:
+          type: string
+          format: uri
+          description: The link to the first page.
+          examples:
+            - https://example-space.signalwire.com/api/projects?page_size=50
+        next:
+          type: string
+          format: uri
+          description: The link to the next page. Only present when more results exist.
+          examples:
+            - https://example-space.signalwire.com/api/projects?page_size=50&page_number=1&page_token=PA8f14e45f
+        prev:
+          type: string
+          format: uri
+          description: The link to the previous page. Only present when a previous page exists.
+          examples:
+            - https://example-space.signalwire.com/api/projects?page_size=50&page_number=0&page_token=PA8f14e45f
+      unevaluatedProperties:
+        not: {}
+      description: Pagination links for a list of projects.
+    Projects.ProjectResponse:
+      type: object
+      required:
+        - id
+        - name
+        - parent_project_id
+        - subproject
+        - region_preference
+        - protect_recordings
+        - protect_message_media
+        - protect_fax_media
+        - force_https_requests
+        - created_at
+        - updated_at
+      properties:
+        id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: The unique identifier of the project.
+          examples:
+            - 8f14e45f-ceea-467d-9c2b-7a1d3a9b2c34
+        name:
+          type: string
+          description: The name of the project.
+          examples:
+            - Acme Staging
+        parent_project_id:
+          anyOf:
+            - $ref: '#/components/schemas/uuid'
+            - type: 'null'
+          description: The unique identifier of the root project. `null` when this project is itself a root project.
+          examples:
+            - b3877739-5c7e-4d4f-9d1a-2f0c8c2f1a11
+        subproject:
+          type: boolean
+          description: '`true` when this project is a subproject.'
+          examples:
+            - true
+        region_preference:
+          type: string
+          description: The effective region preference for the project. Returned in all responses; it is not currently settable through this API.
+          examples:
+            - us-west
+        protect_recordings:
+          type: boolean
+          description: When enabled, recordings created within the project require authentication to access.
+          examples:
+            - false
+        protect_message_media:
+          type: boolean
+          description: When enabled, message media created within the project requires authentication to access.
+          examples:
+            - false
+        protect_fax_media:
+          type: boolean
+          description: When enabled, fax media created within the project requires authentication to access.
+          examples:
+            - false
+        force_https_requests:
+          type: boolean
+          description: When enabled, requests made to the project's webhooks and callbacks must use HTTPS.
+          examples:
+            - true
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time when the project was created.
+          examples:
+            - '2024-05-06T12:20:00Z'
+        updated_at:
+          type: string
+          format: date-time
+          description: The date and time when the project was last updated.
+          examples:
+            - '2024-05-06T12:20:00Z'
+      unevaluatedProperties:
+        not: {}
+      description: A single project.
+    Projects.ProjectWithSigningKey:
+      type: object
+      required:
+        - id
+        - name
+        - parent_project_id
+        - subproject
+        - region_preference
+        - protect_recordings
+        - protect_message_media
+        - protect_fax_media
+        - force_https_requests
+        - created_at
+        - updated_at
+        - signing_key
+      properties:
+        id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: The unique identifier of the project.
+          examples:
+            - 8f14e45f-ceea-467d-9c2b-7a1d3a9b2c34
+        name:
+          type: string
+          description: The name of the project.
+          examples:
+            - Acme Staging
+        parent_project_id:
+          anyOf:
+            - $ref: '#/components/schemas/uuid'
+            - type: 'null'
+          description: The unique identifier of the root project. `null` when this project is itself a root project.
+          examples:
+            - b3877739-5c7e-4d4f-9d1a-2f0c8c2f1a11
+        subproject:
+          type: boolean
+          description: '`true` when this project is a subproject.'
+          examples:
+            - true
+        region_preference:
+          type: string
+          description: The effective region preference for the project. Returned in all responses; it is not currently settable through this API.
+          examples:
+            - us-west
+        protect_recordings:
+          type: boolean
+          description: When enabled, recordings created within the project require authentication to access.
+          examples:
+            - false
+        protect_message_media:
+          type: boolean
+          description: When enabled, message media created within the project requires authentication to access.
+          examples:
+            - false
+        protect_fax_media:
+          type: boolean
+          description: When enabled, fax media created within the project requires authentication to access.
+          examples:
+            - false
+        force_https_requests:
+          type: boolean
+          description: When enabled, requests made to the project's webhooks and callbacks must use HTTPS.
+          examples:
+            - true
+        created_at:
+          type: string
+          format: date-time
+          description: The date and time when the project was created.
+          examples:
+            - '2024-05-06T12:20:00Z'
+        updated_at:
+          type: string
+          format: date-time
+          description: The date and time when the project was last updated.
+          examples:
+            - '2024-05-06T12:20:00Z'
+        signing_key:
+          type: string
+          description: |-
+            The project's signing key. Only returned on create and signing-key rotation responses;
+            it cannot be retrieved through the API afterward.
+          examples:
+            - PSK_4d8c2b1a9f3e7c6d5b4a3e2f1d0c9b8a
+      unevaluatedProperties:
+        not: {}
+      description: |-
+        A project, including its `signing_key`.
+
+        The `signing_key` is only returned when creating a subproject or rotating a project's
+        signing key. It is not retrievable afterward, so capture it from the response.
+      title: Project with signing key
+    Projects.UpdateProjectRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 250
+          description: The name of the project.
+          examples:
+            - Acme Staging (EU)
+        protect_recordings:
+          type: boolean
+          description: When enabled, recordings created within the project require authentication to access.
+          examples:
+            - true
+        protect_message_media:
+          type: boolean
+          description: When enabled, message media created within the project requires authentication to access.
+          examples:
+            - true
+        protect_fax_media:
+          type: boolean
+          description: When enabled, fax media created within the project requires authentication to access.
+          examples:
+            - false
+        force_https_requests:
+          type: boolean
+          description: When enabled, requests made to the project's webhooks and callbacks must use HTTPS.
+          examples:
+            - true
+      unevaluatedProperties:
+        not: {}
+      description: Request body for updating a project's name and settings.
+    Projects.UpdateProjectStatusCode422:
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Types.StatusCodes.RestApiErrorItem'
+          description: List of validation errors.
+      unevaluatedProperties:
+        not: {}
+      description: The request failed validation, for example a blank or overly long `name`.
+      examples:
+        - statusCode: 422
+          errors:
+            - type: validation_error
+              code: invalid_parameter
+              message: Name must be present
+              attribute: name
+              url: https://signalwire.com/docs/apis/error-codes
     PstnRecording:
       type: object
       required:

--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -6473,12 +6473,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
-        '403':
-          description: Access is forbidden.
+        '500':
+          description: An internal server error occurred.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
       tags:
         - Projects
     post:
@@ -6513,12 +6513,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
-        '403':
-          description: Access is forbidden.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
         '422':
           description: |-
             The request could not be processed. When creating a project while authenticated as a
@@ -6528,6 +6522,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Projects.CreateProjectStatusCode422'
+        '500':
+          description: An internal server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
       tags:
         - Projects
       requestBody:
@@ -6558,25 +6558,25 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Projects.ProjectResponse'
+                $ref: '#/components/schemas/Projects.Project'
         '401':
           description: Access is unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
-        '403':
-          description: Access is forbidden.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
         '404':
           description: The server cannot find the requested resource.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode404'
+        '500':
+          description: An internal server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
       tags:
         - Projects
     patch:
@@ -6598,19 +6598,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Projects.ProjectResponse'
+                $ref: '#/components/schemas/Projects.Project'
         '401':
           description: Access is unauthorized.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
-        '403':
-          description: Access is forbidden.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
         '404':
           description: The server cannot find the requested resource.
           content:
@@ -6623,6 +6617,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Projects.UpdateProjectStatusCode422'
+        '500':
+          description: An internal server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
       tags:
         - Projects
       requestBody:
@@ -6660,12 +6660,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
-        '403':
-          description: Access is forbidden.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
         '404':
           description: The server cannot find the requested resource.
           content:
@@ -6681,6 +6675,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Projects.DeleteProjectStatusCode422'
+        '500':
+          description: An internal server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
       tags:
         - Projects
   /api/projects/{id}/signing-key/rotate:
@@ -6713,18 +6713,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
-        '403':
-          description: Access is forbidden.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Types.StatusCodes.StatusCode403'
         '404':
           description: The server cannot find the requested resource.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode404'
+        '500':
+          description: An internal server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
       tags:
         - Projects
   /api/pubsub/tokens:
@@ -28681,84 +28681,6 @@ components:
       unevaluatedProperties:
         not: {}
       description: Pagination links for a list of projects.
-    Projects.ProjectResponse:
-      type: object
-      required:
-        - id
-        - name
-        - parent_project_id
-        - subproject
-        - region_preference
-        - protect_recordings
-        - protect_message_media
-        - protect_fax_media
-        - force_https_requests
-        - created_at
-        - updated_at
-      properties:
-        id:
-          allOf:
-            - $ref: '#/components/schemas/uuid'
-          description: The unique identifier of the project.
-          examples:
-            - 8f14e45f-ceea-467d-9c2b-7a1d3a9b2c34
-        name:
-          type: string
-          description: The name of the project.
-          examples:
-            - Acme Staging
-        parent_project_id:
-          anyOf:
-            - $ref: '#/components/schemas/uuid'
-            - type: 'null'
-          description: The unique identifier of the root project. `null` when this project is itself a root project.
-          examples:
-            - b3877739-5c7e-4d4f-9d1a-2f0c8c2f1a11
-        subproject:
-          type: boolean
-          description: '`true` when this project is a subproject.'
-          examples:
-            - true
-        region_preference:
-          type: string
-          description: The effective region preference for the project. Returned in all responses; it is not currently settable through this API.
-          examples:
-            - us-west
-        protect_recordings:
-          type: boolean
-          description: When enabled, recordings created within the project require authentication to access.
-          examples:
-            - false
-        protect_message_media:
-          type: boolean
-          description: When enabled, message media created within the project requires authentication to access.
-          examples:
-            - false
-        protect_fax_media:
-          type: boolean
-          description: When enabled, fax media created within the project requires authentication to access.
-          examples:
-            - false
-        force_https_requests:
-          type: boolean
-          description: When enabled, requests made to the project's webhooks and callbacks must use HTTPS.
-          examples:
-            - true
-        created_at:
-          type: string
-          format: date-time
-          description: The date and time when the project was created.
-          examples:
-            - '2024-05-06T12:20:00Z'
-        updated_at:
-          type: string
-          format: date-time
-          description: The date and time when the project was last updated.
-          examples:
-            - '2024-05-06T12:20:00Z'
-      unevaluatedProperties:
-        not: {}
-      description: A single project.
     Projects.ProjectWithSigningKey:
       type: object
       required:
@@ -28902,7 +28824,7 @@ components:
               code: invalid_parameter
               message: Name must be present
               attribute: name
-              url: https://signalwire.com/docs/apis/error-codes
+              url: https://signalwire.com/docs/apis/error-codes#invalid_parameter
     PstnRecording:
       type: object
       required:

--- a/fern/products/apis/apis.yml
+++ b/fern/products/apis/apis.yml
@@ -160,6 +160,7 @@ navigation:
               - spaceDomainApplications
             contents: []
           - multiFactorAuthentication
+          - projects
           - projectTokens
           - section: PubSub Tokens
             slug: pubsub

--- a/fern/products/apis/pages/core/error-codes.mdx
+++ b/fern/products/apis/pages/core/error-codes.mdx
@@ -756,6 +756,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 - This parameter must be used in combination with a related parameter.
 </ParamField>
 
+<ParamField path="nested_subprojects_not_allowed" type="Error" toc={true}>
+
+- Subprojects can only be created under a top-level project. Returned by `POST /api/projects` when authenticated as a subproject.
+</ParamField>
+
 <ParamField path="no_channel_specified" type="Error" toc={true}>
 
 - You must specify a channel.
@@ -936,6 +941,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 - The requested assignment would exceed the allowed number of assigned numbers for the selected campaign.
 </ParamField>
 
+<ParamField path="only_subprojects_can_be_deleted" type="Error" toc={true}>
+
+- Only subprojects can be deleted through the API. Returned by `DELETE /api/projects/{id}` when the target is a root/parent project.
+</ParamField>
+
 <ParamField path="out_of_sync" type="Error" toc={true}>
 
 - The resource is out of sync.
@@ -959,6 +969,11 @@ The `code` field above maps to one of the values below. Each entry describes the
 <ParamField path="pft_daily_limit_exceeded" type="Error" toc={true}>
 
 - The Platform Free Trial campaign daily message cap of 200 messages has been reached.
+</ParamField>
+
+<ParamField path="phone_numbers_must_be_removed" type="Error" toc={true}>
+
+- All phone numbers must be removed from a project before it can be deleted. Returned by `DELETE /api/projects/{id}` when the project still has phone numbers assigned.
 </ParamField>
 
 <ParamField path="provided_id_is_unrecognized" type="Error" toc={true}>

--- a/specs/signalwire-rest/main.tsp
+++ b/specs/signalwire-rest/main.tsp
@@ -12,6 +12,7 @@ import "./video-api";
 import "./fabric-api";
 import "./relay-rest";
 import "./project-api";
+import "./projects-api";
 import "./datasphere-api";
 import "./pubsub-api";
 import "./logs-api";
@@ -116,6 +117,8 @@ using TypeSpec.OpenAPI;
 @tagMetadata(SHORT_CODES_TAG, SHORT_CODES_TAG_METADATA)
 // Project API
 @tagMetadata(PROJECT_TOKENS_TAG, PROJECT_TOKENS_TAG_METADATA)
+// Projects Management API
+@tagMetadata(PROJECTS_TAG, PROJECTS_TAG_METADATA)
 // Datasphere API
 @tagMetadata(DOCUMENTS_TAG, DOCUMENTS_TAG_METADATA)
 @tagMetadata(CHUNKS_TAG, CHUNKS_TAG_METADATA)

--- a/specs/signalwire-rest/projects-api/main.tsp
+++ b/specs/signalwire-rest/projects-api/main.tsp
@@ -1,0 +1,140 @@
+import "@typespec/http";
+import "@typespec/openapi";
+import "../types";
+import "./models/core.tsp";
+import "./models/requests.tsp";
+import "./models/responses.tsp";
+import "./models/errors.tsp";
+import "../_globally_shared/const.tsp";
+import "../../_shared/auth.tsp";
+import "../../_shared/alias/token-permissions.tsp";
+import "./tags.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using Types.StatusCodes;
+
+@route("/api/projects")
+namespace SignalWireAPI.Projects {
+  @tag(PROJECTS_TAG)
+  @friendlyName("Projects")
+  interface Projects {
+    @operationId("list_projects")
+    @summary("List projects")
+    @doc("""
+      Lists the authenticated root project and its subprojects.
+      
+      All endpoints operate only within the caller's project tree — the authenticated root
+      project and the subprojects beneath it.
+      
+      ${tokenPermissions<"_Management_">}
+      """)
+    @get
+    list(
+      ...ListProjectsQuery,
+    ): ProjectListResponse | StatusCode401 | StatusCode403;
+
+    @operationId("create_subproject")
+    @summary("Create a subproject")
+    @doc("""
+      Creates a subproject under the authenticated root project.
+      
+      Creating a project is only allowed when authenticated as a top-level (root) project.
+      A subproject cannot itself contain subprojects, so attempting to create one while
+      authenticated as a subproject fails with `422 nested_subprojects_not_allowed`.
+      
+      The response includes the `signing_key`. This is the only time it is returned — it
+      cannot be retrieved through the API afterward, so capture it from this response.
+      
+      ${tokenPermissions<"_Management_">}
+      """)
+    @post
+    create(@body body: CreateProjectRequest):
+      | {
+          @statusCode statusCode: 201;
+          @body body: ProjectWithSigningKey;
+        }
+      | StatusCode401
+      | StatusCode403
+      | CreateProjectStatusCode422;
+
+    @operationId("get_project")
+    @summary("Retrieve a project")
+    @doc("""
+      Retrieves a single project or subproject.
+      
+      A project ID outside the caller's project tree returns `404 Not Found`.
+      
+      ${tokenPermissions<"_Management_">}
+      """)
+    @get
+    read(...ProjectPathID):
+      | ProjectResponse
+      | StatusCode401
+      | StatusCode403
+      | StatusCode404;
+
+    @operationId("update_project")
+    @summary("Update a project")
+    @doc("""
+      Updates a project's name and settings.
+      
+      ${tokenPermissions<"_Management_">}
+      """)
+    @patch(#{ implicitOptionality: true })
+    update(...ProjectPathID, @body body: UpdateProjectRequest):
+      | {
+          @statusCode statusCode: 200;
+          @body body: ProjectResponse;
+        }
+      | StatusCode401
+      | StatusCode403
+      | StatusCode404
+      | UpdateProjectStatusCode422;
+
+    @operationId("delete_subproject")
+    @summary("Delete a subproject")
+    @doc("""
+      Deletes a subproject.
+      
+      Only subprojects can be deleted through this API. Deleting the root/parent project
+      returns `422 only_subprojects_can_be_deleted`. A project must have no phone numbers
+      before it can be deleted; otherwise the request returns `422 phone_numbers_must_be_removed`.
+      
+      On a successful delete, the subproject's registry brands and campaigns are migrated up
+      to the parent project.
+      
+      ${tokenPermissions<"_Management_">}
+      """)
+    @delete
+    delete(...ProjectPathID):
+      | {
+          @statusCode statusCode: 204;
+        }
+      | StatusCode401
+      | StatusCode403
+      | StatusCode404
+      | DeleteProjectStatusCode422;
+
+    @operationId("rotate_signing_key")
+    @summary("Rotate a project's signing key")
+    @doc("""
+      Rotates the project's signing key and returns the project with the new `signing_key`.
+      
+      The previous key may take about 1–2 minutes to stop working. As with create, the
+      `signing_key` is only returned on this response and cannot be retrieved afterward.
+      
+      ${tokenPermissions<"_Management_">}
+      """)
+    @route("/{id}/signing-key/rotate")
+    @post
+    rotateSigningKey(...ProjectPathID):
+      | {
+          @statusCode statusCode: 200;
+          @body body: ProjectWithSigningKey;
+        }
+      | StatusCode401
+      | StatusCode403
+      | StatusCode404;
+  }
+}

--- a/specs/signalwire-rest/projects-api/main.tsp
+++ b/specs/signalwire-rest/projects-api/main.tsp
@@ -32,7 +32,7 @@ namespace SignalWireAPI.Projects {
     @get
     list(
       ...ListProjectsQuery,
-    ): ProjectListResponse | StatusCode401 | StatusCode403;
+    ): ProjectListResponse | StatusCode401 | StatusCode500;
 
     @operationId("create_subproject")
     @summary("Create a subproject")
@@ -55,8 +55,8 @@ namespace SignalWireAPI.Projects {
           @body body: ProjectWithSigningKey;
         }
       | StatusCode401
-      | StatusCode403
-      | CreateProjectStatusCode422;
+      | CreateProjectStatusCode422
+      | StatusCode500;
 
     @operationId("get_project")
     @summary("Retrieve a project")
@@ -69,10 +69,10 @@ namespace SignalWireAPI.Projects {
       """)
     @get
     read(...ProjectPathID):
-      | ProjectResponse
+      | Project
       | StatusCode401
-      | StatusCode403
-      | StatusCode404;
+      | StatusCode404
+      | StatusCode500;
 
     @operationId("update_project")
     @summary("Update a project")
@@ -85,12 +85,12 @@ namespace SignalWireAPI.Projects {
     update(...ProjectPathID, @body body: UpdateProjectRequest):
       | {
           @statusCode statusCode: 200;
-          @body body: ProjectResponse;
+          @body body: Project;
         }
       | StatusCode401
-      | StatusCode403
       | StatusCode404
-      | UpdateProjectStatusCode422;
+      | UpdateProjectStatusCode422
+      | StatusCode500;
 
     @operationId("delete_subproject")
     @summary("Delete a subproject")
@@ -112,9 +112,9 @@ namespace SignalWireAPI.Projects {
           @statusCode statusCode: 204;
         }
       | StatusCode401
-      | StatusCode403
       | StatusCode404
-      | DeleteProjectStatusCode422;
+      | DeleteProjectStatusCode422
+      | StatusCode500;
 
     @operationId("rotate_signing_key")
     @summary("Rotate a project's signing key")
@@ -134,7 +134,7 @@ namespace SignalWireAPI.Projects {
           @body body: ProjectWithSigningKey;
         }
       | StatusCode401
-      | StatusCode403
-      | StatusCode404;
+      | StatusCode404
+      | StatusCode500;
   }
 }

--- a/specs/signalwire-rest/projects-api/models/core.tsp
+++ b/specs/signalwire-rest/projects-api/models/core.tsp
@@ -1,0 +1,97 @@
+import "../../types";
+import "../../_globally_shared/const.tsp";
+
+using TypeSpec.Http;
+
+namespace SignalWireAPI.Projects;
+
+@doc("The unique identifier of a project or subproject.")
+model ProjectPathID {
+  @doc("The unique identifier of the project or subproject.")
+  @example("8f14e45f-ceea-467d-9c2b-7a1d3a9b2c34")
+  @path
+  id: uuid;
+}
+
+@summary("Project")
+@doc("A project or subproject within the caller's project tree.")
+model Project {
+  @doc("The unique identifier of the project.")
+  @example("8f14e45f-ceea-467d-9c2b-7a1d3a9b2c34")
+  id: uuid;
+
+  @doc("The name of the project.")
+  @example("Acme Staging")
+  name: string;
+
+  @doc("The unique identifier of the root project. `null` when this project is itself a root project.")
+  @example("b3877739-5c7e-4d4f-9d1a-2f0c8c2f1a11")
+  parent_project_id: uuid | null;
+
+  @doc("`true` when this project is a subproject.")
+  @example(true)
+  subproject: boolean;
+
+  @doc("The effective region preference for the project. Returned in all responses; it is not currently settable through this API.")
+  @example("us-west")
+  region_preference: string;
+
+  @doc("When enabled, recordings created within the project require authentication to access.")
+  @example(false)
+  protect_recordings: boolean;
+
+  @doc("When enabled, message media created within the project requires authentication to access.")
+  @example(false)
+  protect_message_media: boolean;
+
+  @doc("When enabled, fax media created within the project requires authentication to access.")
+  @example(false)
+  protect_fax_media: boolean;
+
+  @doc("When enabled, requests made to the project's webhooks and callbacks must use HTTPS.")
+  @example(true)
+  force_https_requests: boolean;
+
+  @doc("The date and time when the project was created.")
+  @example(UTC_TIME_EXAMPLE)
+  created_at: utcDateTime;
+
+  @doc("The date and time when the project was last updated.")
+  @example(UTC_TIME_EXAMPLE)
+  updated_at: utcDateTime;
+}
+
+@summary("Project with signing key")
+@doc("""
+  A project, including its `signing_key`.
+  
+  The `signing_key` is only returned when creating a subproject or rotating a project's
+  signing key. It is not retrievable afterward, so capture it from the response.
+  """)
+model ProjectWithSigningKey is Project {
+  @doc("""
+    The project's signing key. Only returned on create and signing-key rotation responses;
+    it cannot be retrieved through the API afterward.
+    """)
+  @example("PSK_4d8c2b1a9f3e7c6d5b4a3e2f1d0c9b8a")
+  signing_key: string;
+}
+
+@doc("Pagination links for a list of projects.")
+model ProjectPaginationLinks {
+  @doc("The link to the current page.")
+  @example("https://example-space.signalwire.com/api/projects?page_size=50")
+  self: url;
+
+  @doc("The link to the first page.")
+  @example("https://example-space.signalwire.com/api/projects?page_size=50")
+  first: url;
+
+  @doc("The link to the next page. Only present when more results exist.")
+  @example("https://example-space.signalwire.com/api/projects?page_size=50&page_number=1&page_token=PA8f14e45f")
+  next?: url;
+
+  @doc("The link to the previous page. Only present when a previous page exists.")
+  @example("https://example-space.signalwire.com/api/projects?page_size=50&page_number=0&page_token=PA8f14e45f")
+  prev?: url;
+}

--- a/specs/signalwire-rest/projects-api/models/errors.tsp
+++ b/specs/signalwire-rest/projects-api/models/errors.tsp
@@ -51,7 +51,7 @@ model DeleteProjectStatusCode422 is StatusCode422;
       code: "invalid_parameter",
       message: "Name must be present",
       attribute: "name",
-      url: "https://signalwire.com/docs/apis/error-codes",
+      url: "https://signalwire.com/docs/apis/error-codes#invalid_parameter",
     }
   ],
 })

--- a/specs/signalwire-rest/projects-api/models/errors.tsp
+++ b/specs/signalwire-rest/projects-api/models/errors.tsp
@@ -1,0 +1,58 @@
+import "../../types/status-codes";
+
+using Types.StatusCodes;
+
+namespace SignalWireAPI.Projects;
+
+@doc("""
+  The request could not be processed. When creating a project while authenticated as a
+  subproject, the response includes the `nested_subprojects_not_allowed` code. A blank or
+  overly long `name` returns a standard validation error.
+  """)
+@example(#{
+  statusCode: 422,
+  errors: #[
+    #{
+      type: "validation_error",
+      code: "nested_subprojects_not_allowed",
+      message: "Subprojects can only be created under a top-level project.",
+      attribute: null,
+      url: "https://signalwire.com/docs/apis/error-codes#nested_subprojects_not_allowed",
+    }
+  ],
+})
+model CreateProjectStatusCode422 is StatusCode422;
+
+@doc("""
+  The request could not be processed. Deleting a root/parent project returns
+  `only_subprojects_can_be_deleted`, and deleting a project that still has phone numbers
+  assigned returns `phone_numbers_must_be_removed`.
+  """)
+@example(#{
+  statusCode: 422,
+  errors: #[
+    #{
+      type: "validation_error",
+      code: "phone_numbers_must_be_removed",
+      message: "All phone numbers must be removed from the project before it can be deleted.",
+      attribute: null,
+      url: "https://signalwire.com/docs/apis/error-codes#phone_numbers_must_be_removed",
+    }
+  ],
+})
+model DeleteProjectStatusCode422 is StatusCode422;
+
+@doc("The request failed validation, for example a blank or overly long `name`.")
+@example(#{
+  statusCode: 422,
+  errors: #[
+    #{
+      type: "validation_error",
+      code: "invalid_parameter",
+      message: "Name must be present",
+      attribute: "name",
+      url: "https://signalwire.com/docs/apis/error-codes",
+    }
+  ],
+})
+model UpdateProjectStatusCode422 is StatusCode422;

--- a/specs/signalwire-rest/projects-api/models/requests.tsp
+++ b/specs/signalwire-rest/projects-api/models/requests.tsp
@@ -1,0 +1,75 @@
+import "./core.tsp";
+
+using TypeSpec.Http;
+
+namespace SignalWireAPI.Projects;
+
+@doc("Request body for creating a subproject.")
+model CreateProjectRequest {
+  @doc("The name of the subproject.")
+  @maxLength(250)
+  @example("Acme Staging")
+  name: string;
+
+  @doc("When enabled, recordings created within the project require authentication to access.")
+  @example(true)
+  protect_recordings?: boolean;
+
+  @doc("When enabled, message media created within the project requires authentication to access.")
+  @example(false)
+  protect_message_media?: boolean;
+
+  @doc("When enabled, fax media created within the project requires authentication to access.")
+  @example(false)
+  protect_fax_media?: boolean;
+
+  @doc("When enabled, requests made to the project's webhooks and callbacks must use HTTPS.")
+  @example(true)
+  force_https_requests?: boolean;
+}
+
+@doc("Request body for updating a project's name and settings.")
+model UpdateProjectRequest {
+  @doc("The name of the project.")
+  @maxLength(250)
+  @example("Acme Staging (EU)")
+  name: string;
+
+  @doc("When enabled, recordings created within the project require authentication to access.")
+  @example(true)
+  protect_recordings?: boolean;
+
+  @doc("When enabled, message media created within the project requires authentication to access.")
+  @example(true)
+  protect_message_media?: boolean;
+
+  @doc("When enabled, fax media created within the project requires authentication to access.")
+  @example(false)
+  protect_fax_media?: boolean;
+
+  @doc("When enabled, requests made to the project's webhooks and callbacks must use HTTPS.")
+  @example(true)
+  force_https_requests?: boolean;
+}
+
+@doc("Query parameters for listing projects.")
+model ListProjectsQuery {
+  @doc("Filter projects by name.")
+  @query
+  name?: string;
+
+  @doc("The number of results per page.")
+  @query
+  @minValue(1)
+  @maxValue(1000)
+  page_size?: int32 = 50;
+
+  @doc("Cursor token for paging, taken from the `links` in a previous response.")
+  @query
+  page_token?: string;
+
+  @doc("The page index, used together with `page_token`.")
+  @query
+  @minValue(0)
+  page_number?: int32 = 0;
+}

--- a/specs/signalwire-rest/projects-api/models/responses.tsp
+++ b/specs/signalwire-rest/projects-api/models/responses.tsp
@@ -1,0 +1,20 @@
+import "./core.tsp";
+import "@typespec/http";
+
+using TypeSpec.Http;
+
+namespace SignalWireAPI.Projects;
+
+@doc("A page of projects.")
+model ProjectListResponse {
+  @doc("Pagination links for the list of projects.")
+  links: ProjectPaginationLinks;
+
+  @doc("The projects on this page.")
+  data: Project[];
+}
+
+@doc("A single project.")
+model ProjectResponse {
+  ...Project;
+}

--- a/specs/signalwire-rest/projects-api/models/responses.tsp
+++ b/specs/signalwire-rest/projects-api/models/responses.tsp
@@ -13,8 +13,3 @@ model ProjectListResponse {
   @doc("The projects on this page.")
   data: Project[];
 }
-
-@doc("A single project.")
-model ProjectResponse {
-  ...Project;
-}

--- a/specs/signalwire-rest/projects-api/tags.tsp
+++ b/specs/signalwire-rest/projects-api/tags.tsp
@@ -1,0 +1,11 @@
+import "@typespec/openapi3";
+
+const PROJECTS_TAG = "Projects";
+
+const PROJECTS_TAG_METADATA = #{
+  description: "Manage projects and subprojects under the authenticated root project.",
+  externalDocs: #{
+    url: "https://signalwire.com/docs/apis",
+    description: "Developer documentation on SignalWire REST APIs",
+  },
+};


### PR DESCRIPTION
## Description

Adds API reference documentation for the new project management endpoints under `/api/projects`. 

Until now, listing, showing, and updating projects (and creating subprojects) was only possible through the LaML `Accounts` API. These native endpoints add scoped project management to the SignalWire REST API.

Notably, only subprojects can be created and deleted using these endpoints. Projects themselves are still managed only in the Dashboard.

The path for these new endpoints is `/api/projects` (plural), not to be confused for the existing `/api/project` (singular) token endpoints. This is intentional. The singular path is a "current project" endpoint — it takes no ID and acts only on the authenticated project, so it cannot address a specific subproject. The plural `projects` path is a standard REST collection that takes an `{id}`, making it much more useful for project management.

The spec is authored in TypeSpec under `specs/signalwire-rest/projects-api/`. The three new error codes (`nested_subprojects_not_allowed`, `only_subprojects_can_be_deleted`, `phone_numbers_must_be_removed`) are also added to the REST error codes doc.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

signalwire/cloud-product#19427

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass