### PR TITLE
Use stable preview URLs (`docs-<pr-number>`)

### DIFF
--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -37,7 +37,8 @@ jobs:
           fi
 
           # --id gives a stable URL (https://fern-preview-<id>.docs.buildwithfern.com/learn).
-          fern generate --docs --preview --id "$PREVIEW_ID" 2>&1 | tee -a /tmp/build.log
+          # Run via `yarn` so the local fern binary in node_modules/.bin is on PATH.
+          yarn fern generate --docs --preview --id "$PREVIEW_ID" 2>&1 | tee -a /tmp/build.log
           if [ ${PIPESTATUS[0]} -ne 0 ]; then
             exit 1
           fi

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -24,31 +24,20 @@ jobs:
         id: generate-docs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
-          # Stable preview id, unique per PR, so each update overwrites the
-          # same named preview instead of spinning up a fresh URL every run.
-          # Repo-qualified (e.g. docs-429) since Fern scopes preview ids to the
-          # org, not the repo — this keeps ids from colliding if another repo in
-          # the org copies this workflow and PR numbers happen to overlap.
+          # Stable, per-PR preview id. Includes repo because Fern scopes preview IDs by org - prevents collisions if another repo later copies this workflow.
           PREVIEW_ID: ${{ github.event.repository.name }}-${{ github.event.pull_request.number }}
         run: |
+          set -eo pipefail
           yarn build:specs 2>&1 | tee /tmp/build.log
-          if [ ${PIPESTATUS[0]} -ne 0 ]; then
-            exit 1
-          fi
+          yarn fern generate --docs --preview --id "$PREVIEW_ID" --force 2>&1 | tee -a /tmp/build.log
 
-          # --id gives a stable URL (https://fern-preview-<id>.docs.buildwithfern.com/learn).
-          # Run via `yarn` so the local fern binary in node_modules/.bin is on PATH.
-          yarn fern generate --docs --preview --id "$PREVIEW_ID" 2>&1 | tee -a /tmp/build.log
-          if [ ${PIPESTATUS[0]} -ne 0 ]; then
-            exit 1
-          fi
-
-          URL=$(grep -oP 'Published docs to \Khttps://[^\s]+' /tmp/build.log | head -1)
+          # Because the script runs under set -e with pipefail, it would abort if grep finds no match and exits non-zero, so || true absorbs that and lets the empty-URL check below handle it.
+          URL=$(grep -oP 'Published docs to \Khttps://[^\s]+' /tmp/build.log | head -1 || true)
           if [ -z "$URL" ]; then
             echo "::error::Could not extract preview URL from build output"
             exit 1
           fi
-          echo "preview_url=$URL" >> $GITHUB_OUTPUT
+          echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Post preview comment
         uses: actions/github-script@v7

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -24,8 +24,20 @@ jobs:
         id: generate-docs
         env:
           FERN_TOKEN: ${{ secrets.FERN_TOKEN }}
+          # Stable preview id, unique per PR, so each update overwrites the
+          # same named preview instead of spinning up a fresh URL every run.
+          # Repo-qualified (e.g. docs-429) since Fern scopes preview ids to the
+          # org, not the repo — this keeps ids from colliding if another repo in
+          # the org copies this workflow and PR numbers happen to overlap.
+          PREVIEW_ID: ${{ github.event.repository.name }}-${{ github.event.pull_request.number }}
         run: |
-          yarn build 2>&1 | tee /tmp/build.log
+          yarn build:specs 2>&1 | tee /tmp/build.log
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            exit 1
+          fi
+
+          # --id gives a stable URL (https://fern-preview-<id>.docs.buildwithfern.com/learn).
+          fern generate --docs --preview --id "$PREVIEW_ID" 2>&1 | tee -a /tmp/build.log
           if [ ${PIPESTATUS[0]} -ne 0 ]; then
             exit 1
           fi

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -2,6 +2,11 @@ name: preview-docs
 
 on: pull_request
 
+# One preview build per PR at a time. Stop existing runs when newer pushes retrigger the workflow.
+concurrency:
+  group: preview-docs-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   preview:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

The existing docs preview workflow regenerates a brand-new preview URL every time you push to a PR branch. This makes preview URLs unstable.

This PR updates the workflow to generate stable, deterministic preview URLs using the `--id` field.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Code cleanup / refactor

## Related Issues

Closes #471 

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [x] All existing tests pass