### PR TITLE
Update default ASR engine

### DIFF
--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -31140,10 +31140,10 @@ components:
             - 1024
         openai_asr_engine:
           type: string
-          description: The ASR (Automatic Speech Recognition) engine to use. Common values include `nova-2` and `nova-3`.
+          description: The ASR (Automatic Speech Recognition) engine to use. Common values include `deepgram:nova-2` and `deepgram:nova-3`.
           examples:
-            - nova-3
-          default: gcloud_speech_v2_async
+            - deepgram:nova-3
+          default: deepgram:nova-3
         outbound_attention_timeout:
           type: integer
           minimum: 10000

--- a/fern/products/swml/pages/reference/methods/calling/ai/ai_params/index.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/ai/ai_params/index.mdx
@@ -191,7 +191,7 @@ Configure how the AI agent processes and understands spoken input, including spe
 </ParamField>
 
 
-<ParamField path="params.openai_asr_engine" type="string" default="gcloud_speech_v2_async" toc={true}>
+<ParamField path="params.openai_asr_engine" type="string" default="deepgram:nova-3" toc={true}>
   The ASR (Automatic Speech Recognition) engine to use. Common values include `deepgram:nova-2`, `deepgram:nova-3`, and other supported ASR engines.
 </ParamField>
 

--- a/specs/swml/calling/Methods/ai/ai_params.tsp
+++ b/specs/swml/calling/Methods/ai/ai_params.tsp
@@ -398,9 +398,9 @@ model AIParams {
   @example(1024)
   max_response_tokens?: integer | SWMLVar;
 
-  @doc("The ASR (Automatic Speech Recognition) engine to use. Common values include `nova-2` and `nova-3`.")
-  @example("nova-3")
-  openai_asr_engine?: string = "gcloud_speech_v2_async";
+  @doc("The ASR (Automatic Speech Recognition) engine to use. Common values include `deepgram:nova-2` and `deepgram:nova-3`.")
+  @example("deepgram:nova-3")
+  openai_asr_engine?: string = "deepgram:nova-3";
 
   @doc("Sets a time duration for the outbound call recipient to respond to the AI agent before timeout, in a range from `10000` to `600000`. **Default:** `120000` ms (2 minutes).")
   @minValue(10000)

--- a/specs/swml/calling/tsp-output/@typespec/json-schema/SWMLObject.json
+++ b/specs/swml/calling/tsp-output/@typespec/json-schema/SWMLObject.json
@@ -5753,11 +5753,11 @@
                 },
                 "openai_asr_engine": {
                     "type": "string",
-                    "default": "gcloud_speech_v2_async",
+                    "default": "deepgram:nova-3",
                     "examples": [
-                        "nova-3"
+                        "deepgram:nova-3"
                     ],
-                    "description": "The ASR (Automatic Speech Recognition) engine to use. Common values include `nova-2` and `nova-3`."
+                    "description": "The ASR (Automatic Speech Recognition) engine to use. Common values include `deepgram:nova-2` and `deepgram:nova-3`."
                 },
                 "outbound_attention_timeout": {
                     "anyOf": [


### PR DESCRIPTION
## Description

The docs stated the default ASR engine for `params.openai_asr_engine` was `gcloud_speech_v2_async`, but the platform default is `deepgram:nova-3`. This PR updates the default in the TypeSpec source and the SWML reference page.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

closes #485 

## Testing

N/A

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [x] All existing tests pass