### PR TITLE
Add error code 30012 to the Compatibility API error codes

### DIFF
--- a/fern/products/compatibility-api/pages/rest-api/core/error-codes.mdx
+++ b/fern/products/compatibility-api/pages/rest-api/core/error-codes.mdx
@@ -566,6 +566,12 @@ Below is a list of all error codes as well as possible causes for the error code
 </ParamField>
 
 
+<ParamField path="30012" type="Error" toc={true}>
+
+- Sending failure. Impossible to send MMS.
+</ParamField>
+
+
 <ParamField path="30022" type="Error" toc={true}>
 
 - The US A2P 10DLC messaging rate limits were exceeded


### PR DESCRIPTION
## Description

Adds error code `30012` to the Compatibility API error codes reference.

`30012` is returned when an MMS could not be sent. This condition was previously reported under the generic `30008` (unknown error); it now has its own code so MMS send failures can be distinguished from other causes of an undelivered message.

Content-only change: one new `ParamField` entry in `fern/products/compatibility-api/pages/rest-api/core/error-codes.mdx`, in numeric order between `30011` and `30022`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

## Testing

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass
