### PR TITLE
Document E911 emergency fields on IncomingPhoneNumber (compat)

### DIFF
--- a/fern/apis/compatibility/openapi.yaml
+++ b/fern/apis/compatibility/openapi.yaml
@@ -8776,6 +8776,21 @@ components:
       unevaluatedProperties:
         not: {}
       description: Response containing a single cXML script.
+    EmergencyAddressStatus:
+      type: string
+      enum:
+        - registered
+        - unregistered
+        - pending-registration
+        - registration-failure
+        - pending-unregistration
+      description: The registration status of the associated E911 address at the carrier.
+    EmergencyStatus:
+      type: string
+      enum:
+        - Active
+        - Inactive
+      description: Emergency status.
     Fax:
       type: object
       required:
@@ -9357,6 +9372,7 @@ components:
         - date_updated
         - emergency_address_sid
         - emergency_status
+        - emergency_address_status
         - friendly_name
         - identity_sid
         - origin
@@ -9438,10 +9454,17 @@ components:
           examples:
             - null
         emergency_status:
-          type: string
-          description: Whether the phone route has an active E911 address associated. 'Active' or 'Inactive'.
+          allOf:
+            - $ref: '#/components/schemas/EmergencyStatus'
+          description: 'Whether emergency (E911) calling is enabled for this phone number, indicated by an associated emergency address. Read-only: enable it by associating an `EmergencyAddressSid`, not by setting this field directly.'
           examples:
             - Inactive
+        emergency_address_status:
+          allOf:
+            - $ref: '#/components/schemas/EmergencyAddressStatus'
+          description: The registration status of the associated E911 address at the carrier. Reflects the asynchronous provisioning lifecycle after an `EmergencyAddressSid` is associated or cleared; `unregistered` when no address is associated.
+          examples:
+            - unregistered
         friendly_name:
           type: string
           description: A formatted version of the number.
@@ -9670,6 +9693,7 @@ components:
         - date_updated
         - emergency_address_sid
         - emergency_status
+        - emergency_address_status
         - friendly_name
         - identity_sid
         - origin
@@ -9751,10 +9775,17 @@ components:
           examples:
             - null
         emergency_status:
-          type: string
-          description: Whether the phone route has an active E911 address associated. 'Active' or 'Inactive'.
+          allOf:
+            - $ref: '#/components/schemas/EmergencyStatus'
+          description: 'Whether emergency (E911) calling is enabled for this phone number, indicated by an associated emergency address. Read-only: enable it by associating an `EmergencyAddressSid`, not by setting this field directly.'
           examples:
             - Inactive
+        emergency_address_status:
+          allOf:
+            - $ref: '#/components/schemas/EmergencyAddressStatus'
+          description: The registration status of the associated E911 address at the carrier. Reflects the asynchronous provisioning lifecycle after an `EmergencyAddressSid` is associated or cleared; `unregistered` when no address is associated.
+          examples:
+            - unregistered
         friendly_name:
           type: string
           description: A formatted version of the number.
@@ -12139,7 +12170,7 @@ components:
         EmergencyAddressSid:
           allOf:
             - $ref: '#/components/schemas/uuid'
-          description: The unique identifier of the address associated with E911 for this phone number. Not supported for toll-free numbers or certain providers.
+          description: The unique identifier of an emergency (E911) address to associate with this phone number. Associating an address triggers asynchronous provisioning at the carrier; track progress with `emergency_address_status`. Pass an empty value to remove the current association. Not supported for toll-free numbers or certain providers.
           examples:
             - b3877c40-da60-4998-90ad-b792e98472ad
         FriendlyName:

--- a/specs/compatibility-api/incoming-phone-numbers/models/core.tsp
+++ b/specs/compatibility-api/incoming-phone-numbers/models/core.tsp
@@ -28,6 +28,15 @@ enum EmergencyStatus {
   Inactive: "Inactive",
 }
 
+@doc("The registration status of the associated E911 address at the carrier.")
+enum EmergencyAddressStatus {
+  Registered: "registered",
+  Unregistered: "unregistered",
+  PendingRegistration: "pending-registration",
+  RegistrationFailure: "registration-failure",
+  PendingUnregistration: "pending-unregistration",
+}
+
 @doc("Phone number origin.")
 enum PhoneNumberOrigin {
   SignalWire: "signalwire",
@@ -97,9 +106,13 @@ model IncomingPhoneNumber {
   @example(null)
   emergency_address_sid: string | null;
 
-  @doc("Whether the phone route has an active E911 address associated. 'Active' or 'Inactive'.")
-  @example("Inactive")
-  emergency_status: string;
+  @doc("Whether emergency (E911) calling is enabled for this phone number, indicated by an associated emergency address. Read-only: enable it by associating an `EmergencyAddressSid`, not by setting this field directly.")
+  @example(EmergencyStatus.Inactive)
+  emergency_status: EmergencyStatus;
+
+  @doc("The registration status of the associated E911 address at the carrier. Reflects the asynchronous provisioning lifecycle after an `EmergencyAddressSid` is associated or cleared; `unregistered` when no address is associated.")
+  @example(EmergencyAddressStatus.Unregistered)
+  emergency_address_status: EmergencyAddressStatus;
 
   @doc("A formatted version of the number.")
   @example("(310) 338-6745")

--- a/specs/compatibility-api/incoming-phone-numbers/models/requests.tsp
+++ b/specs/compatibility-api/incoming-phone-numbers/models/requests.tsp
@@ -80,7 +80,7 @@ model UpdateIncomingPhoneNumberRequest {
   @example("b3877c40-da60-4998-90ad-b792e98472ac")
   AccountSid?: uuid;
 
-  @doc("The unique identifier of the address associated with E911 for this phone number. Not supported for toll-free numbers or certain providers.")
+  @doc("The unique identifier of an emergency (E911) address to associate with this phone number. Associating an address triggers asynchronous provisioning at the carrier; track progress with `emergency_address_status`. Pass an empty value to remove the current association. Not supported for toll-free numbers or certain providers.")
   @example("b3877c40-da60-4998-90ad-b792e98472ad")
   EmergencyAddressSid?: uuid;
 


### PR DESCRIPTION
references https://github.com/signalwire/cloud-product/issues/19831

Documents the LaML `IncomingPhoneNumber` emergency (E911) fields shipped in prime-rails PR signalwire/prime-rails#9563 (in review). Follows the E911 LaML `Addresses` resource docs (#498).

## Changes (`specs/compatibility-api/incoming-phone-numbers/`)
- **New `EmergencyAddressStatus` enum** + `emergency_address_status` response field — the asynchronous carrier registration status (`registered`, `unregistered`, `pending-registration`, `registration-failure`, `pending-unregistration`). `unregistered` when no address is associated.
- **`emergency_status`** typed to its existing `EmergencyStatus` enum (`Active`/`Inactive`) and re-documented as read-only — enabled by associating an address, not by setting the field.
- **`EmergencyAddressSid`** (update request) re-documented: associating triggers asynchronous provisioning at the carrier; an empty value removes the association.

Regenerated `fern/apis/compatibility/openapi.yaml` committed alongside source. `yarn build:specs` + `fern-check` pass locally (only the known unauthenticated redirect-check skip).

## Not covered here (behavioral, for the companion docs issue)
- Error semantics: `EmergencyStatus` is read-only (422 **22222** if set); address validation (**22109**/**21628**); toll-free / unsupported-provider rejection (**21628**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)