### PR TITLE
Document native REST E911 (address validation + phone-number assign/status/remove)

### DIFF
--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -7410,7 +7410,7 @@ paths:
       description: |-
         To create a new Address, make a POST request to the Address resource.
 
-        When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Non-US addresses and requests without `emergency_enabled` are stored without carrier validation.
+        When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Carrier validation applies to US addresses only: a non-US address is stored normally, with `emergency_enabled` returned as `false`. Requests without `emergency_enabled` are stored without carrier validation.
 
         #### Permissions
 
@@ -7419,8 +7419,8 @@ paths:
         [Learn more about API scopes](/docs/platform/your-signalwire-api-space).
       parameters: []
       responses:
-        '201':
-          description: The request has succeeded and a new resource has been created as a result.
+        '200':
+          description: The request has succeeded.
           content:
             application/json:
               schema:
@@ -7432,11 +7432,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
         '422':
-          description: The request failed validation. See errors for details.
+          description: |-
+            The request failed validation. See `errors` for details. When carrier validation rejected the address
+            and the carrier returned alternatives, a `candidates` array is included alongside `errors`; the key is
+            omitted when the carrier returned none.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Types.StatusCodes.ValidationError'
+                $ref: '#/components/schemas/AddressValidationError'
         '500':
           description: An internal server error occurred.
           content:
@@ -7505,7 +7508,7 @@ paths:
       description: |-
         Updates an Address that has been previously created.
 
-        When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Non-US addresses and requests without `emergency_enabled` are stored without carrier validation.
+        When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Carrier validation applies to US addresses only: a non-US address is stored normally, with `emergency_enabled` returned as `false`. Requests without `emergency_enabled` are stored without carrier validation.
 
         #### Permissions
 
@@ -7534,11 +7537,14 @@ paths:
               schema:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode404'
         '422':
-          description: The request failed validation. See errors for details.
+          description: |-
+            The request failed validation. See `errors` for details. When carrier validation rejected the address
+            and the carrier returned alternatives, a `candidates` array is included alongside `errors`; the key is
+            omitted when the carrier returned none.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Types.StatusCodes.ValidationError'
+                $ref: '#/components/schemas/AddressValidationError'
         '500':
           description: An internal server error occurred.
           content:
@@ -14786,6 +14792,53 @@ components:
       unevaluatedProperties:
         not: {}
       description: Address model representing a physical address for regulatory compliance.
+    AddressCandidate:
+      type: object
+      required:
+        - street_number
+        - street_name
+        - city
+        - state
+        - postal_code
+      properties:
+        street_number:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: The number portion of the suggested street address.
+          examples:
+            - '1640'
+        street_name:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: The name portion of the suggested street address.
+          examples:
+            - Riverside Drive
+        city:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: The city portion of the suggested street address.
+          examples:
+            - Alexandria
+        state:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: The state of the suggested street address.
+          examples:
+            - CA
+        postal_code:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: The postal code of the suggested street address.
+          examples:
+            - '91905'
+      unevaluatedProperties:
+        not: {}
+      description: A carrier-suggested alternative to the submitted address.
     AddressChannel:
       anyOf:
         - $ref: '#/components/schemas/AudioChannel'
@@ -14933,6 +14986,27 @@ components:
         - Trailer
         - Unit
       description: Address type for sub-addresses.
+    AddressValidationError:
+      type: object
+      required:
+        - errors
+      properties:
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Types.StatusCodes.SpaceApiErrorItem'
+          description: List of validation errors.
+        candidates:
+          type: array
+          items:
+            $ref: '#/components/schemas/AddressCandidate'
+          description: Alternative addresses suggested by the carrier. Omitted when the carrier returned no alternatives.
+      unevaluatedProperties:
+        not: {}
+      description: |-
+        The request failed validation. See `errors` for details. When carrier validation rejected the address
+        and the carrier returned alternatives, a `candidates` array is included alongside `errors`; the key is
+        omitted when the carrier returned none.
     AssignE911AddressRequest:
       type: object
       required:
@@ -22290,14 +22364,20 @@ components:
             - '91905'
         emergency_enabled:
           type: boolean
-          description: When `true` and the address is in the US, the address is validated against the carrier before it is stored. Defaults to `false` (stored without carrier validation).
+          description: |-
+            Applies to US addresses only. When `true` and `country` is `US`, the address is validated against
+            the carrier before it is stored. For any other `country` the flag is ignored and the response
+            returns `emergency_enabled: false`. Defaults to `false`, which stores the address without carrier
+            validation.
           examples:
             - true
+          default: false
         auto_correct_address:
           type: boolean
           description: When the carrier suggests a corrected version of the address, `true` (the default) stores the corrected address; `false` rejects the request with the suggestion returned as candidates.
           examples:
             - true
+          default: true
       unevaluatedProperties:
         not: {}
       description: Request body for creating an address.
@@ -29172,11 +29252,16 @@ components:
           description: The E911 address ID associated with this phone number.
         e911_status:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/PhoneNumberE911Status'
             - type: 'null'
-          description: 'The E911 provisioning status for this phone number: `pending`, `active`, `failed`, `pending_removal`, or `unregistered`. `null` when no E911 address is associated. Reflects the carrier-confirmed state, never the billing flag.'
+          description: |-
+            The E911 provisioning status for this phone number. `null` when the number has never had an E911
+            address assigned. Once an address is assigned the value is `pending` while the carrier processes
+            the order, then `active` once the carrier confirms the registration, or `failed` if the carrier
+            does not confirm it. Removing the address sets `pending_removal`, and the value becomes
+            `unregistered` once the carrier confirms the removal.
           examples:
-            - null
+            - active
         created_at:
           type: string
           format: date-time
@@ -29447,6 +29532,15 @@ components:
         - mms
         - fax
       description: Phone number capability.
+    PhoneNumberE911Status:
+      type: string
+      enum:
+        - pending
+        - active
+        - failed
+        - pending_removal
+        - unregistered
+      description: E911 provisioning status of a phone number.
     PhoneNumberListResponse:
       type: object
       required:
@@ -29625,11 +29719,16 @@ components:
           description: The E911 address ID associated with this phone number.
         e911_status:
           anyOf:
-            - type: string
+            - $ref: '#/components/schemas/PhoneNumberE911Status'
             - type: 'null'
-          description: 'The E911 provisioning status for this phone number: `pending`, `active`, `failed`, `pending_removal`, or `unregistered`. `null` when no E911 address is associated. Reflects the carrier-confirmed state, never the billing flag.'
+          description: |-
+            The E911 provisioning status for this phone number. `null` when the number has never had an E911
+            address assigned. Once an address is assigned the value is `pending` while the carrier processes
+            the order, then `active` once the carrier confirms the registration, or `failed` if the carrier
+            does not confirm it. Removing the address sets `pending_removal`, and the value becomes
+            `unregistered` once the carrier confirms the removal.
           examples:
-            - null
+            - active
         created_at:
           type: string
           format: date-time
@@ -46270,14 +46369,20 @@ components:
             - '91905'
         emergency_enabled:
           type: boolean
-          description: When `true` and the address is in the US, the address is validated against the carrier before it is stored. Defaults to `false` (stored without carrier validation).
+          description: |-
+            Applies to US addresses only. When `true` and `country` is `US`, the address is validated against
+            the carrier before it is stored. For any other `country` the flag is ignored and the response
+            returns `emergency_enabled: false`. Defaults to `false`, which stores the address without carrier
+            validation.
           examples:
             - true
+          default: false
         auto_correct_address:
           type: boolean
           description: When the carrier suggests a corrected version of the address, `true` (the default) stores the corrected address; `false` rejects the request with the suggestion returned as candidates.
           examples:
             - true
+          default: true
       unevaluatedProperties:
         not: {}
       description: Request body for updating an address.

--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -9065,6 +9065,8 @@ paths:
       description: |-
         Assigns a validated E911 address to the phone number and begins provisioning at the carrier. The number's `e911_status` becomes `pending`; it moves to `active` asynchronously once the carrier confirms. The address is re-validated at the carrier and must be valid.
 
+        The address `label` is sent to the carrier as the caller name presented to the dispatcher. The emergency network limits that field to 32 characters, so a longer label is truncated to the first 32 characters. Truncation never affects the street address used to route the call, and does not cause the assignment to fail.
+
         #### Permissions
 
         The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Numbers_.
@@ -22226,7 +22228,7 @@ components:
         label:
           type: string
           maxLength: 250
-          description: A friendly name given to the address to help distinguish and search for different addresses within your project.
+          description: A friendly name given to the address to help distinguish and search for different addresses within your project. When the address is assigned to a phone number for E911, this label is also sent to the carrier as the caller name. The emergency network limits that field to 32 characters, so longer labels are truncated to the first 32 characters before being sent. Truncation affects only the name shown to the dispatcher, never the address used to route the call.
           examples:
             - My Address
         country:
@@ -46206,7 +46208,7 @@ components:
         label:
           type: string
           maxLength: 250
-          description: A friendly name given to the address to help distinguish and search for different addresses within your project.
+          description: A friendly name given to the address to help distinguish and search for different addresses within your project. When the address is assigned to a phone number for E911, this label is also sent to the carrier as the caller name. The emergency network limits that field to 32 characters, so longer labels are truncated to the first 32 characters before being sent. Truncation affects only the name shown to the dispatcher, never the address used to route the call.
           examples:
             - My Address
         country:

--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -7410,6 +7410,8 @@ paths:
       description: |-
         To create a new Address, make a POST request to the Address resource.
 
+        When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Non-US addresses and requests without `emergency_enabled` are stored without carrier validation.
+
         #### Permissions
 
         The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Numbers_.
@@ -7497,6 +7499,60 @@ paths:
                 $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
       tags:
         - E911 Addresses
+    put:
+      operationId: update_address
+      summary: Update E911 address
+      description: |-
+        Updates an Address that has been previously created.
+
+        When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Non-US addresses and requests without `emergency_enabled` are stored without carrier validation.
+
+        #### Permissions
+
+        The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Numbers_.
+
+        [Learn more about API scopes](/docs/platform/your-signalwire-api-space).
+      parameters:
+        - $ref: '#/components/parameters/AddressPathID'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddressResponse'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode404'
+        '422':
+          description: The request failed validation. See errors for details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.ValidationError'
+        '500':
+          description: An internal server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
+      tags:
+        - E911 Addresses
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateAddressRequest'
     delete:
       operationId: delete_address
       summary: Delete E911 address
@@ -8976,6 +9032,105 @@ paths:
       responses:
         '204':
           description: 'There is no content to send for this request, but the headers may be useful. '
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode404'
+        '422':
+          description: The request failed validation. See errors for details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.ValidationError'
+        '500':
+          description: An internal server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
+      tags:
+        - Phone Numbers
+  /api/relay/rest/phone_numbers/{id}/e911_address:
+    post:
+      operationId: assign_e911_address
+      summary: Assign an E911 address to a phone number
+      description: |-
+        Assigns a validated E911 address to the phone number and begins provisioning at the carrier. The number's `e911_status` becomes `pending`; it moves to `active` asynchronously once the carrier confirms. The address is re-validated at the carrier and must be valid.
+
+        #### Permissions
+
+        The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Numbers_.
+
+        [Learn more about API scopes](/docs/platform/your-signalwire-api-space).
+      parameters:
+        - $ref: '#/components/parameters/PhoneNumberPathID'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PhoneNumberResponse'
+        '401':
+          description: Access is unauthorized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode401'
+        '404':
+          description: The server cannot find the requested resource.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode404'
+        '422':
+          description: The request failed validation. See errors for details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.ValidationError'
+        '500':
+          description: An internal server error occurred.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Types.StatusCodes.StatusCode500'
+      tags:
+        - Phone Numbers
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AssignE911AddressRequest'
+    delete:
+      operationId: remove_e911_address
+      summary: Remove the E911 address from a phone number
+      description: |-
+        Removes the E911 address from the phone number and begins deprovisioning at the carrier. Only allowed while the number is `active`. The `e911_status` becomes `pending_removal`; the address remains associated until the carrier confirms removal.
+
+        #### Permissions
+
+        The API token used to authenticate must have the following scope(s) enabled to make a successful request: _Numbers_.
+
+        [Learn more about API scopes](/docs/platform/your-signalwire-api-space).
+      parameters:
+        - $ref: '#/components/parameters/PhoneNumberPathID'
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PhoneNumberResponse'
         '401':
           description: Access is unauthorized.
           content:
@@ -14535,6 +14690,9 @@ components:
         - state
         - postal_code
         - zip_code
+        - emergency_enabled
+        - validated
+        - validated_at
       properties:
         id:
           allOf:
@@ -14606,6 +14764,23 @@ components:
           description: The postal code of the street address. Alias for postal_code for backwards compatibility.
           examples:
             - '91905'
+        emergency_enabled:
+          type: boolean
+          description: Whether E911 emergency calling is enabled for this address (carrier-validated when created/updated with `emergency_enabled=true` for a US address).
+          examples:
+            - false
+        validated:
+          type: boolean
+          description: Whether the address was validated by the carrier (true when the carrier returned a valid or auto-corrected match).
+          examples:
+            - false
+        validated_at:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: The RFC 3339 / ISO 8601 timestamp of the last successful carrier validation, or null if never validated.
+          examples:
+            - null
       unevaluatedProperties:
         not: {}
       description: Address model representing a physical address for regulatory compliance.
@@ -14648,6 +14823,9 @@ components:
         - state
         - postal_code
         - zip_code
+        - emergency_enabled
+        - validated
+        - validated_at
       properties:
         id:
           allOf:
@@ -14719,6 +14897,23 @@ components:
           description: The postal code of the street address. Alias for postal_code for backwards compatibility.
           examples:
             - '91905'
+        emergency_enabled:
+          type: boolean
+          description: Whether E911 emergency calling is enabled for this address (carrier-validated when created/updated with `emergency_enabled=true` for a US address).
+          examples:
+            - false
+        validated:
+          type: boolean
+          description: Whether the address was validated by the carrier (true when the carrier returned a valid or auto-corrected match).
+          examples:
+            - false
+        validated_at:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: The RFC 3339 / ISO 8601 timestamp of the last successful carrier validation, or null if never validated.
+          examples:
+            - null
       unevaluatedProperties:
         not: {}
       description: Response containing a single address.
@@ -14736,6 +14931,20 @@ components:
         - Trailer
         - Unit
       description: Address type for sub-addresses.
+    AssignE911AddressRequest:
+      type: object
+      required:
+        - e911_address_id
+      properties:
+        e911_address_id:
+          allOf:
+            - $ref: '#/components/schemas/uuid'
+          description: The ID of a validated E911 address in the same project to assign to this phone number.
+          examples:
+            - 3fa85f64-5717-4562-b3fc-2c963f66afa6
+      unevaluatedProperties:
+        not: {}
+      description: Request body for assigning an E911 address to a phone number.
     AssignedNumber:
       type: object
       required:
@@ -22077,6 +22286,16 @@ components:
           description: The postal code of the street address.
           examples:
             - '91905'
+        emergency_enabled:
+          type: boolean
+          description: When `true` and the address is in the US, the address is validated against the carrier before it is stored. Defaults to `false` (stored without carrier validation).
+          examples:
+            - true
+        auto_correct_address:
+          type: boolean
+          description: When the carrier suggests a corrected version of the address, `true` (the default) stores the corrected address; `false` rejects the request with the suggestion returned as candidates.
+          examples:
+            - true
       unevaluatedProperties:
         not: {}
       description: Request body for creating an address.
@@ -28879,6 +29098,7 @@ components:
         - capabilities
         - number_type
         - e911_address_id
+        - e911_status
         - created_at
         - updated_at
         - next_billed_at
@@ -28948,6 +29168,13 @@ components:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
           description: The E911 address ID associated with this phone number.
+        e911_status:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: 'The E911 provisioning status for this phone number: `pending`, `active`, `failed`, `pending_removal`, or `unregistered`. `null` when no E911 address is associated. Reflects the carrier-confirmed state, never the billing flag.'
+          examples:
+            - null
         created_at:
           type: string
           format: date-time
@@ -29324,6 +29551,7 @@ components:
         - capabilities
         - number_type
         - e911_address_id
+        - e911_status
         - created_at
         - updated_at
         - next_billed_at
@@ -29393,6 +29621,13 @@ components:
             - $ref: '#/components/schemas/uuid'
             - type: 'null'
           description: The E911 address ID associated with this phone number.
+        e911_status:
+          anyOf:
+            - type: string
+            - type: 'null'
+          description: 'The E911 provisioning status for this phone number: `pending`, `active`, `failed`, `pending_removal`, or `unregistered`. `null` when no E911 address is associated. Reflects the carrier-confirmed state, never the billing flag.'
+          examples:
+            - null
         created_at:
           type: string
           format: date-time
@@ -45955,6 +46190,95 @@ components:
       unevaluatedProperties:
         not: {}
       description: The request failed validation. See errors for details.
+    UpdateAddressRequest:
+      type: object
+      required:
+        - label
+        - country
+        - first_name
+        - last_name
+        - street_number
+        - street_name
+        - city
+        - state
+        - postal_code
+      properties:
+        label:
+          type: string
+          maxLength: 250
+          description: A friendly name given to the address to help distinguish and search for different addresses within your project.
+          examples:
+            - My Address
+        country:
+          type: string
+          description: The ISO 3166 Alpha 2 country code.
+          examples:
+            - US
+        first_name:
+          type: string
+          maxLength: 250
+          description: First name of the occupant associated with this address.
+          examples:
+            - Emmett
+        last_name:
+          type: string
+          maxLength: 250
+          description: Last name of the occupant associated with this address.
+          examples:
+            - Brown
+        street_number:
+          type: string
+          maxLength: 250
+          description: The number portion of the street address.
+          examples:
+            - '1640'
+        street_name:
+          type: string
+          maxLength: 250
+          description: The name portion of the street address.
+          examples:
+            - Riverside Drive
+        address_type:
+          allOf:
+            - $ref: '#/components/schemas/AddressType'
+          description: 'If the address is divided into multiple sub-addresses, this identifies how the address is divided. Possible values are: Apartment, Basement, Building, Department, Floor, Office, Penthouse, Suite, Trailer, Unit.'
+          examples:
+            - Apartment
+        address_number:
+          type: string
+          description: If the address is divided into multiple sub-addresses, this identifies the particular sub-address.
+          examples:
+            - '42'
+        city:
+          type: string
+          maxLength: 250
+          description: The city portion of the street address.
+          examples:
+            - Alexandria
+        state:
+          type: string
+          description: The state/province/region of the street address. In the USA and Canada, use the two-letter abbreviated form.
+          examples:
+            - CA
+        postal_code:
+          type: string
+          maxLength: 250
+          description: The postal code of the street address.
+          examples:
+            - '91905'
+        emergency_enabled:
+          type: boolean
+          description: When `true` and the address is in the US, the address is validated against the carrier before it is stored. Defaults to `false` (stored without carrier validation).
+          examples:
+            - true
+        auto_correct_address:
+          type: boolean
+          description: When the carrier suggests a corrected version of the address, `true` (the default) stores the corrected address; `false` rejects the request with the suggestion returned as candidates.
+          examples:
+            - true
+      unevaluatedProperties:
+        not: {}
+      description: Request body for updating an address.
     UpdateCampaignRequest:
       type: object
       properties:

--- a/specs/signalwire-rest/relay-rest/addresses/main.tsp
+++ b/specs/signalwire-rest/relay-rest/addresses/main.tsp
@@ -33,7 +33,9 @@ namespace SignalWireAPI.RelayRest.Addresses {
     @summary("Create E911 address")
     @doc("""
       To create a new Address, make a POST request to the Address resource.
-      
+
+      When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Non-US addresses and requests without `emergency_enabled` are stored without carrier validation.
+
       ${tokenPermissions<"_Numbers_">}
       """)
     @post
@@ -51,10 +53,27 @@ namespace SignalWireAPI.RelayRest.Addresses {
     @doc("""
       Retrieves the details of an Address that has been previously created.
       Use the unique ID that was returned from your previous request to identify the specific instance.
-      
+
       ${tokenPermissions<"_Numbers_">}
       """)
     read(...AddressPathID):
+      | AddressResponse
+      | StatusCode401
+      | StatusCode404
+      | ValidationError
+      | StatusCode500;
+
+    @operationId("update_address")
+    @summary("Update E911 address")
+    @doc("""
+      Updates an Address that has been previously created.
+
+      When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Non-US addresses and requests without `emergency_enabled` are stored without carrier validation.
+
+      ${tokenPermissions<"_Numbers_">}
+      """)
+    @put
+    update(...AddressPathID, @body body: UpdateAddressRequest):
       | AddressResponse
       | StatusCode401
       | StatusCode404

--- a/specs/signalwire-rest/relay-rest/addresses/main.tsp
+++ b/specs/signalwire-rest/relay-rest/addresses/main.tsp
@@ -34,18 +34,15 @@ namespace SignalWireAPI.RelayRest.Addresses {
     @doc("""
       To create a new Address, make a POST request to the Address resource.
 
-      When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Non-US addresses and requests without `emergency_enabled` are stored without carrier validation.
+      When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Carrier validation applies to US addresses only: a non-US address is stored normally, with `emergency_enabled` returned as `false`. Requests without `emergency_enabled` are stored without carrier validation.
 
       ${tokenPermissions<"_Numbers_">}
       """)
     @post
     create(@body body: CreateAddressRequest):
-      | {
-          @statusCode statusCode: 201;
-          @body address: AddressResponse;
-        }
+      | AddressResponse
       | StatusCode401
-      | ValidationError
+      | AddressValidationError
       | StatusCode500;
 
     @operationId("get_address")
@@ -68,7 +65,7 @@ namespace SignalWireAPI.RelayRest.Addresses {
     @doc("""
       Updates an Address that has been previously created.
 
-      When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Non-US addresses and requests without `emergency_enabled` are stored without carrier validation.
+      When `emergency_enabled=true` and the address is in the US (`country` = `US`), the address is validated against the carrier. A valid or auto-corrected address is stored (`validated: true`). An address the carrier cannot validate — or a correctable address when `auto_correct_address=false` — is rejected with a `422` whose body includes an `errors` array and a `candidates` array of suggested addresses (each with `street_number`, `street_name`, `city`, `state`, `postal_code`). Carrier validation applies to US addresses only: a non-US address is stored normally, with `emergency_enabled` returned as `false`. Requests without `emergency_enabled` are stored without carrier validation.
 
       ${tokenPermissions<"_Numbers_">}
       """)
@@ -77,7 +74,7 @@ namespace SignalWireAPI.RelayRest.Addresses {
       | AddressResponse
       | StatusCode401
       | StatusCode404
-      | ValidationError
+      | AddressValidationError
       | StatusCode500;
 
     @operationId("delete_address")

--- a/specs/signalwire-rest/relay-rest/addresses/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/addresses/models/core.tsp
@@ -77,4 +77,16 @@ model Address {
   @doc("The postal code of the street address. Alias for postal_code for backwards compatibility.")
   @example("91905")
   zip_code: string;
+
+  @doc("Whether E911 emergency calling is enabled for this address (carrier-validated when created/updated with `emergency_enabled=true` for a US address).")
+  @example(false)
+  emergency_enabled: boolean;
+
+  @doc("Whether the address was validated by the carrier (true when the carrier returned a valid or auto-corrected match).")
+  @example(false)
+  validated: boolean;
+
+  @doc("The RFC 3339 / ISO 8601 timestamp of the last successful carrier validation, or null if never validated.")
+  @example(null)
+  validated_at: string | null;
 }

--- a/specs/signalwire-rest/relay-rest/addresses/models/requests.tsp
+++ b/specs/signalwire-rest/relay-rest/addresses/models/requests.tsp
@@ -4,7 +4,7 @@ using TypeSpec.Http;
 
 @doc("Request body for creating an address.")
 model CreateAddressRequest {
-  @doc("A friendly name given to the address to help distinguish and search for different addresses within your project.")
+  @doc("A friendly name given to the address to help distinguish and search for different addresses within your project. When the address is assigned to a phone number for E911, this label is also sent to the carrier as the caller name. The emergency network limits that field to 32 characters, so longer labels are truncated to the first 32 characters before being sent. Truncation affects only the name shown to the dispatcher, never the address used to route the call.")
   @example("My Address")
   @maxLength(250)
   label: string;
@@ -66,7 +66,7 @@ model CreateAddressRequest {
 
 @doc("Request body for updating an address.")
 model UpdateAddressRequest {
-  @doc("A friendly name given to the address to help distinguish and search for different addresses within your project.")
+  @doc("A friendly name given to the address to help distinguish and search for different addresses within your project. When the address is assigned to a phone number for E911, this label is also sent to the carrier as the caller name. The emergency network limits that field to 32 characters, so longer labels are truncated to the first 32 characters before being sent. Truncation affects only the name shown to the dispatcher, never the address used to route the call.")
   @example("My Address")
   @maxLength(250)
   label: string;

--- a/specs/signalwire-rest/relay-rest/addresses/models/requests.tsp
+++ b/specs/signalwire-rest/relay-rest/addresses/models/requests.tsp
@@ -55,13 +55,18 @@ model CreateAddressRequest {
   @maxLength(250)
   postal_code: string;
 
-  @doc("When `true` and the address is in the US, the address is validated against the carrier before it is stored. Defaults to `false` (stored without carrier validation).")
+  @doc("""
+    Applies to US addresses only. When `true` and `country` is `US`, the address is validated against
+    the carrier before it is stored. For any other `country` the flag is ignored and the response
+    returns `emergency_enabled: false`. Defaults to `false`, which stores the address without carrier
+    validation.
+    """)
   @example(true)
-  emergency_enabled?: boolean;
+  emergency_enabled?: boolean = false;
 
   @doc("When the carrier suggests a corrected version of the address, `true` (the default) stores the corrected address; `false` rejects the request with the suggestion returned as candidates.")
   @example(true)
-  auto_correct_address?: boolean;
+  auto_correct_address?: boolean = true;
 }
 
 @doc("Request body for updating an address.")
@@ -117,11 +122,16 @@ model UpdateAddressRequest {
   @maxLength(250)
   postal_code: string;
 
-  @doc("When `true` and the address is in the US, the address is validated against the carrier before it is stored. Defaults to `false` (stored without carrier validation).")
+  @doc("""
+    Applies to US addresses only. When `true` and `country` is `US`, the address is validated against
+    the carrier before it is stored. For any other `country` the flag is ignored and the response
+    returns `emergency_enabled: false`. Defaults to `false`, which stores the address without carrier
+    validation.
+    """)
   @example(true)
-  emergency_enabled?: boolean;
+  emergency_enabled?: boolean = false;
 
   @doc("When the carrier suggests a corrected version of the address, `true` (the default) stores the corrected address; `false` rejects the request with the suggestion returned as candidates.")
   @example(true)
-  auto_correct_address?: boolean;
+  auto_correct_address?: boolean = true;
 }

--- a/specs/signalwire-rest/relay-rest/addresses/models/requests.tsp
+++ b/specs/signalwire-rest/relay-rest/addresses/models/requests.tsp
@@ -54,4 +54,74 @@ model CreateAddressRequest {
   @example("91905")
   @maxLength(250)
   postal_code: string;
+
+  @doc("When `true` and the address is in the US, the address is validated against the carrier before it is stored. Defaults to `false` (stored without carrier validation).")
+  @example(true)
+  emergency_enabled?: boolean;
+
+  @doc("When the carrier suggests a corrected version of the address, `true` (the default) stores the corrected address; `false` rejects the request with the suggestion returned as candidates.")
+  @example(true)
+  auto_correct_address?: boolean;
+}
+
+@doc("Request body for updating an address.")
+model UpdateAddressRequest {
+  @doc("A friendly name given to the address to help distinguish and search for different addresses within your project.")
+  @example("My Address")
+  @maxLength(250)
+  label: string;
+
+  @doc("The ISO 3166 Alpha 2 country code.")
+  @example("US")
+  country: string;
+
+  @doc("First name of the occupant associated with this address.")
+  @example("Emmett")
+  @maxLength(250)
+  first_name: string;
+
+  @doc("Last name of the occupant associated with this address.")
+  @example("Brown")
+  @maxLength(250)
+  last_name: string;
+
+  @doc("The number portion of the street address.")
+  @example("1640")
+  @maxLength(250)
+  street_number: string;
+
+  @doc("The name portion of the street address.")
+  @example("Riverside Drive")
+  @maxLength(250)
+  street_name: string;
+
+  @doc("If the address is divided into multiple sub-addresses, this identifies how the address is divided. Possible values are: Apartment, Basement, Building, Department, Floor, Office, Penthouse, Suite, Trailer, Unit.")
+  @example(AddressType.Apartment)
+  address_type?: AddressType;
+
+  @doc("If the address is divided into multiple sub-addresses, this identifies the particular sub-address.")
+  @example("42")
+  address_number?: string;
+
+  @doc("The city portion of the street address.")
+  @example("Alexandria")
+  @maxLength(250)
+  city: string;
+
+  @doc("The state/province/region of the street address. In the USA and Canada, use the two-letter abbreviated form.")
+  @example("CA")
+  state: string;
+
+  @doc("The postal code of the street address.")
+  @example("91905")
+  @maxLength(250)
+  postal_code: string;
+
+  @doc("When `true` and the address is in the US, the address is validated against the carrier before it is stored. Defaults to `false` (stored without carrier validation).")
+  @example(true)
+  emergency_enabled?: boolean;
+
+  @doc("When the carrier suggests a corrected version of the address, `true` (the default) stores the corrected address; `false` rejects the request with the suggestion returned as candidates.")
+  @example(true)
+  auto_correct_address?: boolean;
 }

--- a/specs/signalwire-rest/relay-rest/addresses/models/responses.tsp
+++ b/specs/signalwire-rest/relay-rest/addresses/models/responses.tsp
@@ -1,4 +1,5 @@
 import "./core.tsp";
+import "../../../types";
 
 using TypeSpec.Http;
 
@@ -50,4 +51,40 @@ model AddressListResponse {
 @doc("Response containing a single address.")
 model AddressResponse {
   ...Address;
+}
+
+@doc("A carrier-suggested alternative to the submitted address.")
+model AddressCandidate {
+  @doc("The number portion of the suggested street address.")
+  @example("1640")
+  street_number: string | null;
+
+  @doc("The name portion of the suggested street address.")
+  @example("Riverside Drive")
+  street_name: string | null;
+
+  @doc("The city portion of the suggested street address.")
+  @example("Alexandria")
+  city: string | null;
+
+  @doc("The state of the suggested street address.")
+  @example("CA")
+  state: string | null;
+
+  @doc("The postal code of the suggested street address.")
+  @example("91905")
+  postal_code: string | null;
+}
+
+@doc("""
+  The request failed validation. See `errors` for details. When carrier validation rejected the address
+  and the carrier returned alternatives, a `candidates` array is included alongside `errors`; the key is
+  omitted when the carrier returned none.
+  """)
+@error
+model AddressValidationError {
+  ...Types.StatusCodes.ValidationError;
+
+  @doc("Alternative addresses suggested by the carrier. Omitted when the carrier returned no alternatives.")
+  candidates?: AddressCandidate[];
 }

--- a/specs/signalwire-rest/relay-rest/phone-numbers/main.tsp
+++ b/specs/signalwire-rest/relay-rest/phone-numbers/main.tsp
@@ -104,6 +104,8 @@ namespace SignalWireAPI.RelayRest.PhoneNumbers {
     @doc("""
       Assigns a validated E911 address to the phone number and begins provisioning at the carrier. The number's `e911_status` becomes `pending`; it moves to `active` asynchronously once the carrier confirms. The address is re-validated at the carrier and must be valid.
 
+      The address `label` is sent to the carrier as the caller name presented to the dispatcher. The emergency network limits that field to 32 characters, so a longer label is truncated to the first 32 characters. Truncation never affects the street address used to route the call, and does not cause the assignment to fail.
+
       ${tokenPermissions<"_Numbers_">}
       """)
     @route("/{id}/e911_address")

--- a/specs/signalwire-rest/relay-rest/phone-numbers/main.tsp
+++ b/specs/signalwire-rest/relay-rest/phone-numbers/main.tsp
@@ -99,6 +99,38 @@ namespace SignalWireAPI.RelayRest.PhoneNumbers {
       | ValidationError
       | StatusCode500;
 
+    @operationId("assign_e911_address")
+    @summary("Assign an E911 address to a phone number")
+    @doc("""
+      Assigns a validated E911 address to the phone number and begins provisioning at the carrier. The number's `e911_status` becomes `pending`; it moves to `active` asynchronously once the carrier confirms. The address is re-validated at the carrier and must be valid.
+
+      ${tokenPermissions<"_Numbers_">}
+      """)
+    @route("/{id}/e911_address")
+    @post
+    assignE911Address(...PhoneNumberPathID, @body body: AssignE911AddressRequest):
+      | PhoneNumberResponse
+      | StatusCode401
+      | StatusCode404
+      | ValidationError
+      | StatusCode500;
+
+    @operationId("remove_e911_address")
+    @summary("Remove the E911 address from a phone number")
+    @doc("""
+      Removes the E911 address from the phone number and begins deprovisioning at the carrier. Only allowed while the number is `active`. The `e911_status` becomes `pending_removal`; the address remains associated until the carrier confirms removal.
+
+      ${tokenPermissions<"_Numbers_">}
+      """)
+    @route("/{id}/e911_address")
+    @delete
+    removeE911Address(...PhoneNumberPathID):
+      | PhoneNumberResponse
+      | StatusCode401
+      | StatusCode404
+      | ValidationError
+      | StatusCode500;
+
     @operationId("search_available_phone_numbers")
     @summary("Search phone numbers")
     @doc("""

--- a/specs/signalwire-rest/relay-rest/phone-numbers/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/phone-numbers/models/core.tsp
@@ -21,6 +21,15 @@ enum PhoneNumberType {
   longcode: "longcode",
 }
 
+@doc("E911 provisioning status of a phone number.")
+enum PhoneNumberE911Status {
+  pending: "pending",
+  active: "active",
+  failed: "failed",
+  pending_removal: "pending_removal",
+  unregistered: "unregistered",
+}
+
 @doc("Phone number capability.")
 enum PhoneNumberCapability {
   voice: "voice",
@@ -111,9 +120,15 @@ model PhoneNumber {
   @doc("The E911 address ID associated with this phone number.")
   e911_address_id: uuid | null;
 
-  @doc("The E911 provisioning status for this phone number: `pending`, `active`, `failed`, `pending_removal`, or `unregistered`. `null` when no E911 address is associated. Reflects the carrier-confirmed state, never the billing flag.")
-  @example(null)
-  e911_status: string | null;
+  @doc("""
+    The E911 provisioning status for this phone number. `null` when the number has never had an E911
+    address assigned. Once an address is assigned the value is `pending` while the carrier processes
+    the order, then `active` once the carrier confirms the registration, or `failed` if the carrier
+    does not confirm it. Removing the address sets `pending_removal`, and the value becomes
+    `unregistered` once the carrier confirms the removal.
+    """)
+  @example(PhoneNumberE911Status.active)
+  e911_status: PhoneNumberE911Status | null;
 
   @doc("The date the number was added to your project.")
   created_at: utcDateTime;

--- a/specs/signalwire-rest/relay-rest/phone-numbers/models/core.tsp
+++ b/specs/signalwire-rest/relay-rest/phone-numbers/models/core.tsp
@@ -111,6 +111,10 @@ model PhoneNumber {
   @doc("The E911 address ID associated with this phone number.")
   e911_address_id: uuid | null;
 
+  @doc("The E911 provisioning status for this phone number: `pending`, `active`, `failed`, `pending_removal`, or `unregistered`. `null` when no E911 address is associated. Reflects the carrier-confirmed state, never the billing flag.")
+  @example(null)
+  e911_status: string | null;
+
   @doc("The date the number was added to your project.")
   created_at: utcDateTime;
 

--- a/specs/signalwire-rest/relay-rest/phone-numbers/models/requests.tsp
+++ b/specs/signalwire-rest/relay-rest/phone-numbers/models/requests.tsp
@@ -112,6 +112,13 @@ model UpdatePhoneNumberRequest {
   message_relay_application?: string;
 }
 
+@doc("Request body for assigning an E911 address to a phone number.")
+model AssignE911AddressRequest {
+  @doc("The ID of a validated E911 address in the same project to assign to this phone number.")
+  @example("3fa85f64-5717-4562-b3fc-2c963f66afa6")
+  e911_address_id: uuid;
+}
+
 @doc("Request body for importing a phone number.")
 model ImportPhoneNumberRequest {
   @doc("The phone number to import in E.164 format. Number must be between 5 and 30 characters with no special characters besides a leading +.")


### PR DESCRIPTION
references https://github.com/signalwire/cloud-product/issues/19835 and https://github.com/signalwire/cloud-product/issues/20062

Documents the native REST E911 API (`/api/relay/rest`, under `specs/signalwire-rest/relay-rest/`), shipped in prime-rails PRs signalwire/prime-rails#9565 (merged) and signalwire/prime-rails#9575 (in review).

## Addresses resource (Slice A — #19835)
- **New request fields** on create/update: `emergency_enabled` (when true + US, validates the address at the carrier before storing) and `auto_correct_address` (governs whether a carrier correction is stored or returned as a suggestion).
- **New `update` operation** (`PUT /addresses/{id}`) — completes CRUD.
- **New response fields**: `emergency_enabled`, `validated`, `validated_at`.
- Carrier-validation behavior + the `422` candidates response documented in the create/update descriptions.

## Phone numbers resource (Slice B — #20062)
- **New `e911_status` response field** (native vocab: `pending`/`active`/`failed`/`pending_removal`/`unregistered`; carrier-confirmed, never the billing flag).
- **New nested sub-resource**: `POST /phone_numbers/{id}/e911_address` (assign + provision) and `DELETE /phone_numbers/{id}/e911_address` (remove, active-only).

Regenerated `fern/apis/signalwire-rest/openapi.yaml` committed alongside source. `yarn build:specs` + `fern-check` pass locally (only the known unauthenticated redirect-check skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)