### PR TITLE
Migrate GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -48,15 +48,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 
       - name: Cache lychee
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/lychee
           key: lychee-${{ runner.os }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload link report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: link-report
           path: /tmp/link-report.md

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -15,10 +15,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 
@@ -45,7 +45,7 @@ jobs:
           echo "preview_url=$URL" >> "$GITHUB_OUTPUT"
 
       - name: Post preview comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PREVIEW_URL: ${{ steps.generate-docs.outputs.preview_url }}
         with:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -11,10 +11,10 @@ jobs:
     if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/heads/main') && github.run_number > 1 }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
 

--- a/.github/workflows/publish-postman.yml
+++ b/.github/workflows/publish-postman.yml
@@ -53,9 +53,9 @@ jobs:
             collection_id: ${{ vars.POSTMAN_COMPATIBILITY_COLLECTION_ID }}
     steps:
       - name: Checkout
-        # Pinned to commit SHA (v4.2.2) — tags are mutable and a tag
+        # Pinned to commit SHA (v5.1.0) — tags are mutable and a tag
         # repoint by a compromised upstream would run with our secrets.
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5.1.0
         with:
           fetch-depth: 2  # need HEAD^ for the per-spec diff
 
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Node.js
         if: steps.changed.outputs.changed == 'true'
         # Pinned to commit SHA for the same reason as actions/checkout above.
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5.0.0
         with:
           node-version: '22'
 

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v11
         with:
           stale-pr-message: 'This PR is stale because it has been open 25 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           close-pr-message: 'This PR was closed because it has been inactive for 5 days after being marked stale.'


### PR DESCRIPTION
## Description

GitHub is retiring the node20 action runtime, so this bumps every first-party action in our workflows to a major version that runs on node24: 

- `checkout` v5
- `setup-node` v5
- `cache` v6
- `upload-artifact` v7
- `github-script` v9
- `stale` v11

All jobs run on GitHub-hosted `ubuntu-latest` runners, which already meet the 2.327.1 minimum runner version required by node24 actions.

Two actions are deliberately not on their latest major. `checkout` (now at v7) and `setup-node` (now at v6) are bumped only to v5 — the lowest major on node24 — because their newer majors carry behavioral changes we don't need: `checkout` v6 changed credential persistence and v7 blocks fork-PR checkout under `pull_request_target`, while `setup-node` v6 restricted automatic caching to npm. The remaining actions went straight to latest since their intervening majors were runtime/ESM updates only.

The SHA-pinned actions in `publish-postman.yml` were repinned to the commits for `checkout` v5.1.0 and `setup-node` v5.0.0, keeping that file's pin-by-SHA convention. The inline script in `preview-docs.yml` is unaffected by `github-script` v9's ESM changes — it only uses the injected `github`/`context` objects. `taiki-e/install-action` is a composite action and doesn't use the node runtime, so it's untouched.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Code cleanup / refactor

## Related Issues

Addresses #528 

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [x] All existing tests pass