### PR TITLE
Document status callbacks as advisory notifications, not realtime triggers

### DIFF
--- a/fern/apis/compatibility/openapi.yaml
+++ b/fern/apis/compatibility/openapi.yaml
@@ -12417,6 +12417,8 @@ webhooks:
 
                 Your app can use these parameters to handle the transcription — for example, uploading the text to
                 your CRM, sending it via email, or forwarding the body via SignalWire SMS.
+
+                Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       responses:
         '200':
           description: Webhook received
@@ -12429,6 +12431,8 @@ webhooks:
 
         Your app can use these parameters to handle the transcription — for example, uploading the text to
         your CRM, sending it via email, or forwarding the body via SignalWire SMS.
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       tags:
         - Recording Transcriptions
   voiceStatusCallback:
@@ -12651,6 +12655,8 @@ webhooks:
 
                 Use `StatusCallbackEvent` to receive every call progress event — not just the final status —
                 along with current call state and all parameters below.
+
+                Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       responses:
         '200':
           description: Webhook received
@@ -12666,6 +12672,8 @@ webhooks:
 
         Use `StatusCallbackEvent` to receive every call progress event — not just the final status —
         along with current call state and all parameters below.
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       tags:
         - Calls
   recordingStatusCallback:
@@ -12753,6 +12761,8 @@ webhooks:
                 | `in-progress` | The recording has begun. |
                 | `completed` | The file is available for access. |
                 | `absent` | The recording was too short or the call was silent — no audio was detected. |
+
+                Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       responses:
         '200':
           description: Webhook received
@@ -12777,6 +12787,8 @@ webhooks:
         | `in-progress` | The recording has begun. |
         | `completed` | The file is available for access. |
         | `absent` | The recording was too short or the call was silent — no audio was detected. |
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       tags:
         - Recordings
   incomingCallStatusCallback:
@@ -12846,6 +12858,8 @@ webhooks:
 
                 By default, the webhook fires only when the call is `completed` or `failed`, making it well-suited
                 for tracking inbound call success rate, call quality, and total call volume in a call center context.
+
+                Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       responses:
         '200':
           description: Webhook received
@@ -12859,6 +12873,8 @@ webhooks:
 
         By default, the webhook fires only when the call is `completed` or `failed`, making it well-suited
         for tracking inbound call success rate, call quality, and total call volume in a call center context.
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       tags:
         - Incoming Phone Numbers
   smsStatusCallback:
@@ -12960,6 +12976,8 @@ webhooks:
                 left SignalWire and reached the downstream peer. Some carriers send delayed DLRs; others send none
                 at all. MMS messages never receive DLRs, so they will only ever reach `sent` status.
                 </Note>
+
+                Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       responses:
         '200':
           description: Webhook received
@@ -12988,5 +13006,7 @@ webhooks:
         left SignalWire and reached the downstream peer. Some carriers send delayed DLRs; others send none
         at all. MMS messages never receive DLRs, so they will only ever reach `sent` status.
         </Note>
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       tags:
         - Messages

--- a/fern/apis/signalwire-rest/openapi.yaml
+++ b/fern/apis/signalwire-rest/openapi.yaml
@@ -20689,6 +20689,8 @@ components:
         Sent to your `status_url` when a background audio stream started with
         `calling.stream` changes state. `params.state` is `streaming` when the stream
         starts and `finished` when it ends.
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       title: Stream status callback
     Calling.StreamStatusUrlMethod:
       type: string
@@ -20952,6 +20954,8 @@ components:
         Sent to your `status_url` when the call's transcription is ready.
         `calling.transcript.completed` includes the transcribed text;
         `calling.transcript.failed` means the call could not be transcribed.
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       title: Transcript status callback
     Calling.TtsGender:
       type: string
@@ -27748,6 +27752,8 @@ components:
         Payload sent by SignalWire to the `status_callback` URL each time a message transitions to a new state. The same payload shape is used for RELAY SDK message callbacks, SWML `send_sms` status callbacks, and SWML messaging `reply.status_url` callbacks.
 
         Configure `status_callback` when [sending a message](/docs/apis/rest/messages/create-message).
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       title: Message status callback
     Message.MessagesCreateStatusCode422:
       type: object
@@ -51771,6 +51777,8 @@ webhooks:
                 Sent to your `status_url` when a background audio stream started with
                 `calling.stream` changes state. `params.state` is `streaming` when the stream
                 starts and `finished` when it ends.
+
+                Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       responses:
         '200':
           description: Webhook received
@@ -51778,6 +51786,8 @@ webhooks:
         Sent to your `status_url` when a background audio stream started with
         `calling.stream` changes state. `params.state` is `streaming` when the stream
         starts and `finished` when it ends.
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       tags:
         - Calls
   transcribeStatusCallback:
@@ -51853,6 +51863,8 @@ webhooks:
                 Sent to your `status_url` when the call's transcription is ready.
                 `calling.transcript.completed` includes the transcribed text;
                 `calling.transcript.failed` means the call could not be transcribed.
+
+                Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       responses:
         '200':
           description: Webhook received
@@ -51860,6 +51872,8 @@ webhooks:
         Sent to your `status_url` when the call's transcription is ready.
         `calling.transcript.completed` includes the transcribed text;
         `calling.transcript.failed` means the call could not be transcribed.
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       tags:
         - Calls
   messageStatusCallback:
@@ -51955,6 +51969,8 @@ webhooks:
                 Payload sent by SignalWire to the `status_callback` URL each time a message transitions to a new state. The same payload shape is used for RELAY SDK message callbacks, SWML `send_sms` status callbacks, and SWML messaging `reply.status_url` callbacks.
 
                 Configure `status_callback` when [sending a message](/docs/apis/rest/messages/create-message).
+
+                Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       responses:
         '200':
           description: Webhook received
@@ -51962,6 +51978,8 @@ webhooks:
         Payload sent by SignalWire to the `status_callback` URL each time a message transitions to a new state. The same payload shape is used for RELAY SDK message callbacks, SWML `send_sms` status callbacks, and SWML messaging `reply.status_url` callbacks.
 
         Configure `status_callback` when [sending a message](/docs/apis/rest/messages/create-message).
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       tags:
         - Messages
   inboundMessageWebhook:
@@ -52500,6 +52518,8 @@ webhooks:
                 | `pending` → `failed` | `number_assignment_failed` | The number was not assigned to the campaign. |
                 | `failed` → `pending` | `number_assignment_pending` | A failed assignment is being retried. |
                 | `pending` → `completed` | `number_assignment_activated` | The number has been successfully assigned to the campaign. |
+
+                Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       responses:
         '200':
           description: Webhook received
@@ -52541,5 +52561,7 @@ webhooks:
         | `pending` → `failed` | `number_assignment_failed` | The number was not assigned to the campaign. |
         | `failed` → `pending` | `number_assignment_pending` | A failed assignment is being retried. |
         | `pending` → `completed` | `number_assignment_activated` | The number has been successfully assigned to the campaign. |
+
+        Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
       tags:
         - Campaign Registry

--- a/fern/products/compatibility-api/pages/cxml/guides/webhooks/common-webhook-errors.mdx
+++ b/fern/products/compatibility-api/pages/cxml/guides/webhooks/common-webhook-errors.mdx
@@ -7,9 +7,11 @@ Below are some examples of common errors that you might encounter when using web
 
 ## HTML retrieval error (error code 11200)
 
-HTML Retrieval Errors happen when there is a failure to retrieve the contents of the URL in your webhook. This indicates that SignalWire tried to reach your URL but did not receive a response before the connection timed out. Our current timeouts are 2 seconds for Connect and 5 seconds for Read, and we retry twice once the connection times out.
+HTML Retrieval Errors happen when there is a failure to retrieve the contents of the URL in your webhook. This indicates that SignalWire tried to reach your URL but did not receive a response before the connection timed out. Our current timeouts are 2 seconds for Connect and 5 seconds for Read.
 
-SignalWire automatically retries HTTP retrieval requests. If it's an action type of webhook, SignalWire won't attempt a retry but will go to the fallback URL (on inbound calls, can specify an action URL and a fallback URL). If it's a status callback webhook, SignalWire will retry three times, and back off slightly between each attempt. So the second one will retry very quickly, and for the third retry, the system will wait a few seconds.
+If it's an action type of webhook, SignalWire won't attempt a retry but will go to the fallback URL (on inbound calls, can specify an action URL and a fallback URL). If it's a status callback webhook, SignalWire will retry up to two more times — three attempts in total.
+
+If all retries fail, the callback is not delivered and no further notification is made — treat status callbacks as advisory and reconcile state via the [REST API](/docs/compatibility-api/rest/calls/retrieve-a-call) for critical workflows.
 
 If you only experienced this error temporarily only to see the same webhook work successfully later, your web server was likely temporarily unavailable or experiencing a network outage. If this issue is persisting, we recommend taking a look at your systems to verify there are no processes or queries taking too long to return.
 

--- a/fern/products/compatibility-api/pages/cxml/guides/webhooks/index.mdx
+++ b/fern/products/compatibility-api/pages/cxml/guides/webhooks/index.mdx
@@ -47,6 +47,8 @@ When one of your SignalWire phone numbers receives a call or is used to place an
 
 SignalWire will send you a status callback when the call is completed unless directed otherwise; you can use the events `initiated`, `ringing`, `answered`, and `completed` in the `StatusCallbackEvent` parameter in order to get updates when each of those statuses is reached.
 
+For time-critical logic during the call itself, prefer the `<Dial>` [`action` URL](/docs/compatibility-api/cxml/reference/voice/dial#dial_action), which receives the dial outcome as part of document execution.
+
 ### Recording Status Callback
 
 If you are recording your voice calls, you may notice that the recording is not always instantly available due to the need for some audio processing to transcode it into a compressed audio format after the voice call is complete. If you would like to be notified when it's done, you can use recording status callbacks!
@@ -165,3 +167,5 @@ https://example.com/foo#ot=1000
 ```
 https://example.com/foo#ot=1000&rt=1000
 ```
+
+Timeout overrides tune delivery, but do not make callbacks reliable — see [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).

--- a/fern/products/compatibility-api/pages/cxml/guides/webhooks/index.mdx
+++ b/fern/products/compatibility-api/pages/cxml/guides/webhooks/index.mdx
@@ -41,6 +41,8 @@ You will receive an incoming voice call webhook request when you have your webho
 
 ### Status Callback
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 When one of your SignalWire phone numbers receives a call or is used to place an outgoing call, you can have asynchronous HTTP requests sent to your server that tell you about the status changes and the call details. You can do this by setting the `StatusCallback` parameter when [placing an outbound call](/docs/compatibility-api/rest/calls/create-a-call) through the API.
 
 SignalWire will send you a status callback when the call is completed unless directed otherwise; you can use the events `initiated`, `ringing`, `answered`, and `completed` in the `StatusCallbackEvent` parameter in order to get updates when each of those statuses is reached.
@@ -66,6 +68,8 @@ It is also possible to receive an incoming text message, and not send a reply me
 ```
 
 ### Status Callbacks
+
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
 
 Like status callbacks for voice, SMS status callbacks are a way to have updates on the delivery of your messages sent directly to your server! Each time the message status changes (e.g., from `queued` to `sending` to `sent` to `delivered`), SignalWire will send an update to the URL that you have designated.
 

--- a/fern/products/compatibility-api/pages/cxml/messaging/overview.mdx
+++ b/fern/products/compatibility-api/pages/cxml/messaging/overview.mdx
@@ -132,6 +132,8 @@ Responses to the HTTP request are in **SignalWire cXML**. SignalWire starts at t
 
 ## Status callbacks
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 SignalWire can send your application callbacks at various lifecycle stages of your message. Status callbacks do not allow you to change the application execution directly, so callbacks do not have to respond with SignalWire cXML, but they allow your application to get updates as a message is happening.
 
 You should respond to any callbacks with a `200 OK` or `204 No Content`, otherwise, you will see failures in your application log on SignalWire.

--- a/fern/products/compatibility-api/pages/cxml/voice/overview.mdx
+++ b/fern/products/compatibility-api/pages/cxml/voice/overview.mdx
@@ -143,6 +143,8 @@ Responses to the HTTP request are in SignalWire cXML. SignalWire starts at the t
 
 #### Status callbacks
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 SignalWire can send your application callbacks at various lifecycle stages of your call. Status callbacks do not allow you to change the application execution directly, so callbacks do not have to respond with SignalWire cXML, but they allow your application to get updates as a call is happening.
 
 You should respond to any callbacks with a `200 OK` or `204 No Content`, otherwise you will see failures in your application log on SignalWire.

--- a/fern/products/platform/pages/platform/core/webhooks/index.mdx
+++ b/fern/products/platform/pages/platform/core/webhooks/index.mdx
@@ -86,7 +86,7 @@ Click **Edit Settings**. Under **Inbound Call Settings** (or **Inbound Message S
 ## Status callbacks to keep track of events
 
 Status callbacks are asynchronous HTTP requests SignalWire sends to your server as a call, 
-message, or recording moves through its lifecycle, so your application can react to each state change as it happens.
+message, or recording moves through its lifecycle, keeping your application informed of each state change.
 
 ```mermaid
 flowchart LR
@@ -116,6 +116,36 @@ SignalWire only marks a message **Delivered** once it receives a Delivery Receip
 A status of **Sent** means the message left SignalWire successfully. 
 MMS messages do not support DLRs, so they only ever show **Sent**.
 </Info>
+
+### Status callbacks are advisory [#status-callback-reliability]
+
+Status callbacks are best-effort notifications, not a reliable realtime signal.
+They are delivered asynchronously over HTTP, so a callback can arrive late, arrive after a retry,
+or not arrive at all — if your server is unreachable when SignalWire sends the request, the
+callback is simply lost, and nothing notifies your application that it was missed.
+Because a missed callback is invisible to the receiver, never gate time-critical or
+business-critical actions (billing, compliance steps, call teardown, failover) solely on
+receiving one.
+
+For critical paths, use a mechanism whose failure modes are visible to your application:
+
+- **[RELAY over WebSocket](/docs/server-sdks/reference/python/relay)** (also for
+  [TypeScript](/docs/server-sdks/reference/typescript/relay)) — events arrive over a persistent
+  connection, so your client knows immediately when it is disconnected and can fail safe.
+  See the RELAY events reference for
+  [Python](/docs/server-sdks/reference/python/relay/events) and
+  [TypeScript](/docs/server-sdks/reference/typescript/relay/events).
+- **REST polling and reconciliation** — treat a callback as a hint: confirm the state with a
+  `GET` before acting, and run a periodic sweep to catch missed callbacks. Use
+  [Retrieve a call](/docs/compatibility-api/rest/calls/retrieve-a-call) and
+  [Retrieve a message](/docs/compatibility-api/rest/messages/retrieve-message) on the
+  Compatibility API, or [voice logs](/docs/apis/rest/voice-logs/get-voice-log) and
+  [message logs](/docs/apis/rest/message-logs/get-message-log) on the SignalWire REST API.
+- **In-call flow logic** — act on results inside the call flow instead of out-of-band. SWML's
+  [`connect`](/docs/swml/reference/calling/connect#variables) sets result variables
+  (`connect_result`) you can branch on, and cXML's
+  [`<Dial>` `action` URL](/docs/compatibility-api/cxml/reference/voice/dial#dial_action)
+  receives the dial outcome as part of document execution.
 
 <CardGroup cols={2}>
 <Card

--- a/fern/products/swml/pages/reference/methods/calling/connect/index.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/connect/index.mdx
@@ -865,6 +865,8 @@ Set by the method:
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `call_state_url` with a JSON payload when the call state changes.
 Only events listed in `call_state_events` will be sent (default: `ended`).
 

--- a/fern/products/swml/pages/reference/methods/calling/detect_machine.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/detect_machine.mdx
@@ -101,6 +101,8 @@ You can reference these variables in your SWML script utilizing the `${variable}
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `status_url` with a JSON payload like the following:
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/enter_queue.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/enter_queue.mdx
@@ -58,6 +58,8 @@ After the bridge completes (when the agent or caller hangs up), execution contin
 
 ## **Queue Status Callbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 When you provide a `status_url`, SignalWire will send HTTP POST requests to that URL for the following queue events.
 
 ### Event Object Structure

--- a/fern/products/swml/pages/reference/methods/calling/join_conference.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/join_conference.mdx
@@ -194,6 +194,8 @@ This method allows you to connect the current call to a named conference where m
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `status_callback` with a JSON payload for events specified in `status_callback_event`. Both conference and recording events share the same `calling.conference` event type; the specific event is identified by `params.status`.
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/pay/index.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/pay/index.mdx
@@ -269,6 +269,8 @@ sections:
 
 ## `status_url` request body
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 The `status_url` parameter is used to send requests for each status change during the payment process.
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/play/index.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/play/index.mdx
@@ -63,6 +63,8 @@ Read by the method:
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `status_url` with a JSON payload like the following:
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/prompt.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/prompt.mdx
@@ -129,6 +129,8 @@ Read by the method:
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `status_url` with a JSON payload like the following:
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/receive_fax.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/receive_fax.mdx
@@ -38,6 +38,8 @@ Set by the method:
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `status_url` with a JSON payload like the following:
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/record.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/record.mdx
@@ -79,6 +79,8 @@ Set by the method:
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `status_url` with a JSON payload like the following:
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/record_call.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/record_call.mdx
@@ -86,6 +86,8 @@ Set by the method:
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `status_url` with a JSON payload like the following:
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/send_fax.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/send_fax.mdx
@@ -54,6 +54,8 @@ Set by the method:
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `status_url` with a JSON payload like the following:
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/send_sms.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/send_sms.mdx
@@ -100,6 +100,8 @@ Set by the method:
 
 ## **Status callbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 When `status_callback` is set, SignalWire sends an HTTP `POST` to that URL each time the outbound
 message transitions to a new state. Callback delivery is independent of SWML execution: the document
 continues as soon as the message is accepted, and delivery-state callbacks fire afterwards.

--- a/fern/products/swml/pages/reference/methods/calling/sip_refer.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/sip_refer.mdx
@@ -52,6 +52,8 @@ Set by the method:
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `status_url` with a JSON payload like the following:
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/stream.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/stream.mdx
@@ -79,6 +79,8 @@ The stream keeps running until you stop it with [`stop_stream`](/docs/swml/refer
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 When you set `status_url`, SignalWire POSTs a `calling.call.stream` event to it whenever the stream changes state: `params.state` is `streaming` when the stream starts and `finished` when it ends.
 
 <WebhookPayloadSnippet webhook="streamStatusCallback" />

--- a/fern/products/swml/pages/reference/methods/calling/tap.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/tap.mdx
@@ -67,6 +67,8 @@ Set by the method:
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 A POST request will be sent to `status_url` with a JSON payload like the following:
 
 <ParamField path="event_type" type="string" toc={true}>

--- a/fern/products/swml/pages/reference/methods/calling/transcribe.mdx
+++ b/fern/products/swml/pages/reference/methods/calling/transcribe.mdx
@@ -41,6 +41,8 @@ Only one transcription can be active on a call at a time. Starting another while
 
 ## **StatusCallbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 When you set `status_url`, SignalWire POSTs a transcript event to it when the call's transcription finishes: `calling.transcript.completed` includes the transcribed `text` when speech was captured, or `calling.transcript.failed` if the call could not be transcribed.
 
 <WebhookPayloadSnippet webhook="transcribeStatusCallback" />

--- a/fern/products/swml/pages/reference/methods/messaging/reply.mdx
+++ b/fern/products/swml/pages/reference/methods/messaging/reply.mdx
@@ -133,6 +133,8 @@ document, both variables reflect the most recent reply.
 
 ## **Status callbacks**
 
+<Markdown src="/snippets/common/_status-callback-advisory.mdx" />
+
 The `status_url` on `reply` registers a delivery status callback for the **outbound reply message** —
 not for the inbound message that triggered the SWML document. It behaves the same way as the status
 callback on any other outbound message sent through SignalWire.

--- a/fern/snippets/common/_status-callback-advisory.mdx
+++ b/fern/snippets/common/_status-callback-advisory.mdx
@@ -1,0 +1,5 @@
+{/* Shared component: Status callback advisory */}
+
+<Note title="Status callbacks are advisory">
+Status callbacks are asynchronous, best-effort HTTP notifications: delivery can be delayed or fail silently — if your server is unreachable, the callback simply never arrives. Don't gate time-critical or business-critical actions solely on receiving one. Confirm state via the REST API before acting, or use a transport with visible failure modes — see [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
+</Note>

--- a/specs/compatibility-api/calls/models/webhooks.tsp
+++ b/specs/compatibility-api/calls/models/webhooks.tsp
@@ -13,6 +13,8 @@ import "../../../_shared/webhook/decorator.tsp";
 
   Use `StatusCallbackEvent` to receive every call progress event — not just the final status —
   along with current call state and all parameters below.
+
+  Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
   """)
 model VoiceStatusCallbackPayload {
   @doc("The unique ID of the project this call is associated with.")
@@ -190,6 +192,8 @@ model VoiceStatusCallbackPayload {
   | `in-progress` | The recording has begun. |
   | `completed` | The file is available for access. |
   | `absent` | The recording was too short or the call was silent — no audio was detected. |
+
+  Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
   """)
 model RecordingStatusCallbackPayload {
   @doc("The unique ID of the project this call is associated with.")

--- a/specs/compatibility-api/incoming-phone-numbers/models/webhooks.tsp
+++ b/specs/compatibility-api/incoming-phone-numbers/models/webhooks.tsp
@@ -11,6 +11,8 @@ import "../../../_shared/webhook/decorator.tsp";
 
   By default, the webhook fires only when the call is `completed` or `failed`, making it well-suited
   for tracking inbound call success rate, call quality, and total call volume in a call center context.
+
+  Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
   """)
 model InboundCallStatusCallbackPayload {
   @doc("A unique identifier for the call. May be used to later retrieve this call from the REST API.")

--- a/specs/compatibility-api/messages/models/webhooks.tsp
+++ b/specs/compatibility-api/messages/models/webhooks.tsp
@@ -26,6 +26,8 @@ import "../../../_shared/webhook/decorator.tsp";
   left SignalWire and reached the downstream peer. Some carriers send delayed DLRs; others send none
   at all. MMS messages never receive DLRs, so they will only ever reach `sent` status.
   </Note>
+
+  Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
   """)
 model SmsStatusCallbackPayload {
   @doc("""

--- a/specs/compatibility-api/transcriptions/models/webhooks.tsp
+++ b/specs/compatibility-api/transcriptions/models/webhooks.tsp
@@ -10,6 +10,8 @@ import "../../../_shared/webhook/decorator.tsp";
 
   Your app can use these parameters to handle the transcription — for example, uploading the text to
   your CRM, sending it via email, or forwarding the body via SignalWire SMS.
+
+  Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
   """)
 model TranscriptionStatusCallbackPayload {
   @doc("The unique, 34-character ID of the transcription.")

--- a/specs/signalwire-rest/calling-api/calls/models/webhooks.tsp
+++ b/specs/signalwire-rest/calling-api/calls/models/webhooks.tsp
@@ -8,6 +8,8 @@ namespace SignalWireAPI.Calling;
   Sent to your `status_url` when the call's transcription is ready.
   `calling.transcript.completed` includes the transcribed text;
   `calling.transcript.failed` means the call could not be transcribed.
+
+  Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
   """)
 model TranscribeStatusCallbackPayload {
   @doc("Whether the transcription completed or failed.")
@@ -51,6 +53,8 @@ model TranscribeStatusCallbackPayload {
   Sent to your `status_url` when a background audio stream started with
   `calling.stream` changes state. `params.state` is `streaming` when the stream
   starts and `finished` when it ends.
+
+  Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
   """)
 model StreamStatusCallbackPayload {
   @doc("The type of event. Always `calling.call.stream` for stream status callbacks.")

--- a/specs/signalwire-rest/message-api/messages/models/webhooks.tsp
+++ b/specs/signalwire-rest/message-api/messages/models/webhooks.tsp
@@ -9,6 +9,8 @@ namespace SignalWireAPI.Message;
   Payload sent by SignalWire to the `status_callback` URL each time a message transitions to a new state. The same payload shape is used for RELAY SDK message callbacks, SWML `send_sms` status callbacks, and SWML messaging `reply.status_url` callbacks.
 
   Configure `status_callback` when [sending a message](/docs/apis/rest/messages/create-message).
+
+  Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
   """)
 model MessageStatusCallbackPayload {
   @doc("The unique ID of the message segment.")

--- a/specs/signalwire-rest/relay-rest/campaign-registry/models/webhooks.tsp
+++ b/specs/signalwire-rest/relay-rest/campaign-registry/models/webhooks.tsp
@@ -39,6 +39,8 @@ import "../../../../_shared/webhook/decorator.tsp";
   | `pending` → `failed` | `number_assignment_failed` | The number was not assigned to the campaign. |
   | `failed` → `pending` | `number_assignment_pending` | A failed assignment is being retried. |
   | `pending` → `completed` | `number_assignment_activated` | The number has been successfully assigned to the campaign. |
+
+  Status callbacks are advisory, best-effort notifications — delivery can be delayed or fail silently, so don't gate time-critical actions on receiving one. See [Status callback reliability](/docs/platform/webhooks#status-callback-reliability).
   """)
 model TenDlcStatusCallbackPayload {
   @doc("The unique ID of the project this object is associated with.")


### PR DESCRIPTION
## Description

Status callbacks are not built to be reliable realtime signals for critical actions. Until now, the docs did not clarify this, and the platform webhooks page implied the opposite ("react to each state change as it happens").

### Changes/Additions

**Canonical posture section:** The platform Webhooks doc gets a new "Status callbacks are advisory" section (`#status-callback-reliability` for quick linking). It declares that callbacks are asynchronous, best-effort notifications whose failure mode is invisible to the receiver (a missed callback simply never arrives), so time-critical and business-critical actions must not gate solely on receiving one. It describes and links the alternatives with visible failure modes:

- **RELAY over WebSocket:** events arrive over a persistent connection, so disconnection is detectable and the client can fail safe
- **REST polling and reconciliation:** treat a callback as a hint: confirm state via `GET` before acting, sweep for missed callbacks (Compatibility API retrieve-a-call / retrieve-a-message; voice-logs / message-logs on the SignalWire REST API, which has no GET-call endpoint)
- **In-call flow logic:** SWML `connect` result variables, cXML `<Dial>` `action` URL

**Shared advisory snippet:** Added a new `fern/snippets/common/_status-callback-advisory.mdx` (`<Note>`), which is embedded immediately after the status-callback heading on every page that documents them: 
- cXML webhooks guide (voice + SMS sections)
- cXML voice/messaging overviews
- all 16 SWML method reference pages

**TypeSpec:** Added a one-sentence advisory to all 8 status-callback payload model `@doc` blocks and regenerated OpenAPI. This propagates to the generated REST webhook reference pages and every `<WebhookPayloadSnippet>` embed. The AI sidecar/SWAIG webhooks are deliberately excluded; those are synchronous request/response webhooks, not status callbacks.

**cXML guide corrections:** The retry description in `common-webhook-errors.mdx` contradicted itself ("we retry twice" vs. "retry three times... the second one will retry very quickly"). I standardized this to the source-verified count, **"SignalWire will retry up to two more times — three attempts in total"**, and removed incorrect retry-timing claims. Also added:
- A note that exhausted retries fail silently
- A pointer to the `<Dial>` `action` URL for time-critical in-call logic
- A note that timeout overrides tune delivery but don't make callbacks reliable

### Deferred

Verifying the docs against source surfaced several discrepancies that need confirmation of intended behavior before documenting:
- retry backoff timing
- message callbacks not retrying transport failures
- `#tt` fragment parameter is unhandled on the status-callback path
- documented `ot`/`rt` ranges don't match the actual 500–10000ms clamp
- the HMAC signature computed over the URL includes the fragment, but the request is sent without it

### Verification

- `yarn build:specs`, `yarn fern-check`, and full `yarn build` (preview deploy) pass
- All new internal links and anchors verified against the preview deployment

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

#532 

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the project's style guidelines
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)
- [x] All existing tests pass