### PR TITLE
Add server-rendered llms.txt discovery hints for AI agents

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -28,6 +28,17 @@ agents:
     For a complete index of all SignalWire documentation pages, fetch
     https://signalwire.com/docs/llms.txt
 
+# Workaround for Fern's agent-directive div pointing to /llms.txt, which 404s
+# on our subpath domain. The bar is hidden from humans in styles.css but the
+# text stays in the server-rendered HTML for non-JS fetchers. Remove once Fern
+# renders the correct basePath-aware directive.
+announcement:
+  message: >-
+    <span class="llms-hint">For AI agents: the complete SignalWire
+    documentation index is at https://signalwire.com/docs/llms.txt. Append
+    /llms.txt to any URL for a section-level index, or .md to any page URL for
+    its markdown version.</span>
+
 experimental:
   ai-examples: false
   mdx-components:
@@ -126,6 +137,9 @@ logo:
   href: /docs
 
 navbar-links:
+  - type: minimal
+    text: llms.txt
+    href: https://signalwire.com/docs/llms.txt
   - type: minimal
     text: Log in
     href: https://signalwire.com/signin

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -28,17 +28,6 @@ agents:
     For a complete index of all SignalWire documentation pages, fetch
     https://signalwire.com/docs/llms.txt
 
-# Workaround for Fern's agent-directive div pointing to /llms.txt, which 404s
-# on our subpath domain. The bar is hidden from humans in styles.css but the
-# text stays in the server-rendered HTML for non-JS fetchers. Remove once Fern
-# renders the correct basePath-aware directive.
-announcement:
-  message: >-
-    <span class="llms-hint">For AI agents: the complete SignalWire
-    documentation index is at https://signalwire.com/docs/llms.txt. Append
-    /llms.txt to any URL for a section-level index, or .md to any page URL for
-    its markdown version.</span>
-
 experimental:
   ai-examples: false
   mdx-components:

--- a/fern/products/apis/pages/core/overview.mdx
+++ b/fern/products/apis/pages/core/overview.mdx
@@ -4,6 +4,8 @@ title: Overview
 slug: /
 ---
 
+<Markdown src="/snippets/llms-hint.mdx" />
+
 Welcome to the SignalWire REST API. Every capability on the platform — placing calls, sending messages, managing phone numbers, running video rooms, building AI agents — is reachable through a consistent set of HTTP endpoints under your Space's subdomain.
 
 Requests and responses are JSON over HTTPS, authenticated with your Project ID and API token. Endpoints follow standard [REST](https://en.wikipedia.org/wiki/REST) conventions: predictable resource URLs, conventional HTTP verbs, and structured status codes for every outcome — including errors.

--- a/fern/products/browser-sdk/pages/v4/guides/getting-started/overview.mdx
+++ b/fern/products/browser-sdk/pages/v4/guides/getting-started/overview.mdx
@@ -6,6 +6,8 @@ position: 1
 max-toc-depth: 3
 ---
 
+<Markdown src="/snippets/llms-hint.mdx" />
+
 The SignalWire Browser SDK puts voice, video, and chat in a browser
 without plugins, downloads, or a media server you have to run. It also integrates with
 powerful AI agents, [SWML](/docs/swml), and all telephony and communication services SignalWire provides.

--- a/fern/products/call-flow-builder/pages/core/overview.mdx
+++ b/fern/products/call-flow-builder/pages/core/overview.mdx
@@ -9,6 +9,8 @@ slug: /
 max-toc-depth: 3
 ---
 
+<Markdown src="/snippets/llms-hint.mdx" />
+
 ## Introduction
 
 Call Flow Builder is a no-code visual tool for creating and managing voice applications directly in the Dashboard.

--- a/fern/products/compatibility-api/pages/cxml/core/overview.mdx
+++ b/fern/products/compatibility-api/pages/cxml/core/overview.mdx
@@ -6,6 +6,8 @@ slug: /
 position: 0
 ---
 
+<Markdown src="/snippets/llms-hint.mdx" />
+
 The SignalWire Compatibility API provides a seamless migration path from Twilio* to SignalWire. If you've built applications using Twilio's TwiML, REST API, or helper libraries, you can transition to SignalWire with minimal code changes while gaining access to SignalWire's powerful infrastructure and competitive pricing.
 
 

--- a/fern/products/home/pages/welcome.mdx
+++ b/fern/products/home/pages/welcome.mdx
@@ -7,6 +7,8 @@ hide-toc: true
 layout: custom
 ---
 
+<Markdown src="/snippets/llms-hint.mdx" />
+
 <div class="lp-page-container">
   <div class="main-content">
     {/* Dashed Pattern */}

--- a/fern/products/platform/pages/getting-started.mdx
+++ b/fern/products/platform/pages/getting-started.mdx
@@ -6,6 +6,8 @@ slug: getting-started
 position: 0
 ---
 
+<Markdown src="/snippets/llms-hint.mdx" />
+
 SignalWire is a programmable unified communications platform that unifies voice, messaging, video, and AI into a single control plane.
 SignalWire's APIs and SDKs enable developers to build state-of-the-art realtime communication experiences without needing to
 manage complex telecom infrastructure or stitch together disconnected tools.

--- a/fern/products/server-sdks/pages/guides/getting-started/overview.mdx
+++ b/fern/products/server-sdks/pages/guides/getting-started/overview.mdx
@@ -7,6 +7,8 @@ position: 0
 max-toc-depth: 3
 ---
 
+<Markdown src="/snippets/llms-hint.mdx" />
+
 [installation]: /docs/server-sdks/guides/installation
 [quick-start]: /docs/server-sdks/guides/quickstart
 [development-environment]: /docs/server-sdks/guides/dev-environment

--- a/fern/products/swml/pages/get-started/index.mdx
+++ b/fern/products/swml/pages/get-started/index.mdx
@@ -9,6 +9,7 @@ slug: /
 max-toc-depth: 3
 ---
 
+<Markdown src="/snippets/llms-hint.mdx" />
 
 SWML is a markup and scripting language for quickly writing powerful communication applications in YAML or JSON documents. SWML is easy to use, and enables you to create powerful voice and messaging applications using a descriptive format.
 

--- a/fern/snippets/llms-hint.mdx
+++ b/fern/snippets/llms-hint.mdx
@@ -1,0 +1,3 @@
+<llms-ignore>
+  <div className="llms-hint" aria-hidden="true">For AI agents: the complete SignalWire documentation index is at https://signalwire.com/docs/llms.txt. Append /llms.txt to any URL for a section-level index, or .md to any page URL for its markdown version.</div>
+</llms-ignore>

--- a/fern/styles.css
+++ b/fern/styles.css
@@ -506,3 +506,32 @@ a[href*="god.gw.postman.com"] > img {
 .fern-sidebar-group-level-1.mt-2 > li:last-child {
   margin-bottom: 0;
 }
+
+/* =============================================================================
+   AI-AGENT DISCOVERY HINTS (llms.txt)
+   Fern's built-in agent directive points to /llms.txt, which 404s on our
+   subpath domain (real path: /docs/llms.txt). Until Fern ships a basePath-
+   aware directive, we ship our own hints in server-rendered HTML:
+   - .llms-hint: visually-hidden text block (snippets/llms-hint.mdx and the
+     announcement message in docs.yml) that stays readable to non-JS fetchers.
+   - The announcement bar is repurposed as a site-wide carrier and hidden
+     from humans entirely.
+   ========================================================================== */
+.llms-hint {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Hide the announcement bar that carries the hint. Scoped via :has(.llms-hint)
+   so a future human-facing announcement (without the span) stays visible. */
+.fern-announcement:has(.llms-hint),
+[class*="announcement"]:has(.llms-hint) {
+  display: none !important;
+}

--- a/fern/styles.css
+++ b/fern/styles.css
@@ -511,11 +511,9 @@ a[href*="god.gw.postman.com"] > img {
    AI-AGENT DISCOVERY HINTS (llms.txt)
    Fern's built-in agent directive points to /llms.txt, which 404s on our
    subpath domain (real path: /docs/llms.txt). Until Fern ships a basePath-
-   aware directive, we ship our own hints in server-rendered HTML:
-   - .llms-hint: visually-hidden text block (snippets/llms-hint.mdx and the
-     announcement message in docs.yml) that stays readable to non-JS fetchers.
-   - The announcement bar is repurposed as a site-wide carrier and hidden
-     from humans entirely.
+   aware directive, snippets/llms-hint.mdx ships the correct hint in the
+   server-rendered HTML of entry pages; this class keeps it visually hidden
+   while staying readable to non-JS fetchers.
    ========================================================================== */
 .llms-hint {
   position: absolute;
@@ -527,11 +525,4 @@ a[href*="god.gw.postman.com"] > img {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
-}
-
-/* Hide the announcement bar that carries the hint. Scoped via :has(.llms-hint)
-   so a future human-facing announcement (without the span) stays visible. */
-.fern-announcement:has(.llms-hint),
-[class*="announcement"]:has(.llms-hint) {
-  display: none !important;
 }


### PR DESCRIPTION
## Description

Fern's built-in AI-agent directive (a hidden `sr-only` div on every page) tells agents to fetch the docs index "at the root level at /llms.txt". But on our subpath custom domain, that link isn't right; the index actually lives at [signalwire.com/docs/llms.txt](https://signalwire.com/docs/llms.txt). 

The div isn't configurable from `docs.yml` and is rendered by Fern's cloud frontend, so this PR ships our own correct hints in server-rendered HTML (visible to non-JS fetchers like Claude's).

An open [bug report](https://github.com/fern-api/fern/issues/17322) alerted Fern that the built-in hint should be `basePath`-aware.

Two mechanisms, all additive and easy to remove once Fern fixes their side:

1. A minimal `llms.txt` navbar link — a plain server-rendered anchor, also useful to humans.
2. A visually-hidden hint block (`fern/snippets/llms-hint.mdx`) included on the landing page and each product's entry page, wrapped in `<llms-ignore>` so it stays out of the `.md`/llms.txt output that already carries the correct directive via `agents.page-directive`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code cleanup / refactor

## Related Issues

https://github.com/fern-api/fern/issues/17322

## Testing

<!-- How did you test your changes? -->

- [ ] Added/updated unit tests
- [ ] Tested manually
- [ ] Tested with live SignalWire credentials (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [ ] My code follows the project's style guidelines
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)
- [ ] All existing tests pass

## Additional Notes

<!-- Any other context about the PR -->
