### PR TITLE
chore: add .git-blame-ignore-revs for CRLF normalization

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,6 @@
+# Bulk formatting-only commits to skip in git blame.
+# GitHub's blame view picks this file up automatically; locally, opt in with:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# chore: normalize CRLF line endings to LF in SWML pages (#546)
+5b40cfa190e692a42e04acffef5a9b2c938ad821


### PR DESCRIPTION
## Description

Adds .git-blame-ignore-revs listing the CRLF -> LF normalization commit from #546.

GitHub's blame view honors this file automatically. Locally, opt in with `git config blame.ignoreRevsFile .git-blame-ignore-revs`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Code cleanup / refactor

## Related Issues

#546 
